### PR TITLE
feat/battery ck startup

### DIFF
--- a/apps/battery-node/include/peripherals.h
+++ b/apps/battery-node/include/peripherals.h
@@ -23,10 +23,17 @@ typedef struct {
   UART_HandleTypeDef huart1;
 } peripherals_t;
 
+typedef struct {
+  uint8_t prescaler;
+  uint8_t tseg1;
+  uint8_t tseg2;
+  uint8_t sjw;
+} can_bit_timing_t;
+
 peripherals_t *get_peripherals(void);
 void adc1_init(void);
 void adc2_init(void);
-void can_init(void);
+int can_init(can_bit_timing_t *bit_timing);
 void i2c1_init(void);
 void spi1_init(void);
 void uart1_init(void);

--- a/apps/battery-node/src/main.c
+++ b/apps/battery-node/src/main.c
@@ -236,7 +236,7 @@ void mayor_init(void) {
   }
 
   // Go on bus in silent mode
-  if (ck_set_comm_mode(CK_COMM_MODE_COMMUNICATE) != CK_OK) {
+  if (ck_set_comm_mode(CK_COMM_MODE_SILENT) != CK_OK) {
     print(&peripherals->huart1, "Error setting comm mode.\r\n");
     error();
   }

--- a/apps/battery-node/src/peripherals.c
+++ b/apps/battery-node/src/peripherals.c
@@ -169,14 +169,118 @@ void adc2_init(void) {
  * @param None
  * @retval None
  */
-void can_init(void) {
+int can_init(can_bit_timing_t* bit_timing) {
   CAN_HandleTypeDef* hcan = &peripherals.hcan;
   hcan->Instance = CAN;
-  hcan->Init.Prescaler = 18;  // NOLINT
+
+  if (bit_timing->prescaler < 1) {
+    return APP_NOT_OK;
+  }
+
+  hcan->Init.Prescaler = bit_timing->prescaler;
   hcan->Init.Mode = CAN_MODE_NORMAL;
-  hcan->Init.SyncJumpWidth = CAN_SJW_1TQ;
-  hcan->Init.TimeSeg1 = CAN_BS1_13TQ;
-  hcan->Init.TimeSeg2 = CAN_BS2_2TQ;
+
+  switch (bit_timing->sjw) {
+    case 1:
+      hcan->Init.SyncJumpWidth = CAN_SJW_1TQ;
+      break;
+    case 2:
+      hcan->Init.SyncJumpWidth = CAN_SJW_2TQ;
+      break;
+    case 3:
+      hcan->Init.SyncJumpWidth = CAN_SJW_3TQ;
+      break;
+    case 4:
+      hcan->Init.SyncJumpWidth = CAN_SJW_4TQ;
+      break;
+    default:
+      return APP_NOT_OK;
+  }
+
+  // NOLINTBEGIN(*-magic-numbers)
+  switch (bit_timing->tseg1) {
+    case 1:
+      hcan->Init.TimeSeg1 = CAN_BS1_1TQ;
+      break;
+    case 2:
+      hcan->Init.TimeSeg1 = CAN_BS1_2TQ;
+      break;
+    case 3:
+      hcan->Init.TimeSeg1 = CAN_BS1_3TQ;
+      break;
+    case 4:
+      hcan->Init.TimeSeg1 = CAN_BS1_4TQ;
+      break;
+    case 5:
+      hcan->Init.TimeSeg1 = CAN_BS1_5TQ;
+      break;
+    case 6:
+      hcan->Init.TimeSeg1 = CAN_BS1_6TQ;
+      break;
+    case 7:
+      hcan->Init.TimeSeg1 = CAN_BS1_7TQ;
+      break;
+    case 8:
+      hcan->Init.TimeSeg1 = CAN_BS1_8TQ;
+      break;
+    case 9:
+      hcan->Init.TimeSeg1 = CAN_BS1_9TQ;
+      break;
+    case 10:
+      hcan->Init.TimeSeg1 = CAN_BS1_10TQ;
+      break;
+    case 11:
+      hcan->Init.TimeSeg1 = CAN_BS1_11TQ;
+      break;
+    case 12:
+      hcan->Init.TimeSeg1 = CAN_BS1_12TQ;
+      break;
+    case 13:
+      hcan->Init.TimeSeg1 = CAN_BS1_13TQ;
+      break;
+    case 14:
+      hcan->Init.TimeSeg1 = CAN_BS1_14TQ;
+      break;
+    case 15:
+      hcan->Init.TimeSeg1 = CAN_BS1_15TQ;
+      break;
+    case 16:
+      hcan->Init.TimeSeg1 = CAN_BS1_16TQ;
+      break;
+    default:
+      return APP_NOT_OK;
+  }
+
+  switch (bit_timing->tseg2) {
+    case 1:
+      hcan->Init.TimeSeg2 = CAN_BS2_1TQ;
+      break;
+    case 2:
+      hcan->Init.TimeSeg2 = CAN_BS2_2TQ;
+      break;
+    case 3:
+      hcan->Init.TimeSeg2 = CAN_BS2_3TQ;
+      break;
+    case 4:
+      hcan->Init.TimeSeg2 = CAN_BS2_4TQ;
+      break;
+    case 5:
+      hcan->Init.TimeSeg2 = CAN_BS2_5TQ;
+      break;
+    case 6:
+      hcan->Init.TimeSeg2 = CAN_BS2_6TQ;
+      break;
+    case 7:
+      hcan->Init.TimeSeg2 = CAN_BS2_7TQ;
+      break;
+    case 8:
+      hcan->Init.TimeSeg2 = CAN_BS2_8TQ;
+      break;
+    default:
+      return APP_NOT_OK;
+  }
+  // NOLINTEND(*-magic-numbers)
+
   hcan->Init.TimeTriggeredMode = DISABLE;
   hcan->Init.AutoBusOff = DISABLE;
   hcan->Init.AutoWakeUp = DISABLE;
@@ -184,7 +288,7 @@ void can_init(void) {
   hcan->Init.ReceiveFifoLocked = DISABLE;
   hcan->Init.TransmitFifoPriority = DISABLE;
   if (HAL_CAN_Init(hcan) != HAL_OK) {
-    error();
+    return APP_NOT_OK;
   }
 
   CAN_FilterTypeDef allow_all = {
@@ -200,8 +304,10 @@ void can_init(void) {
   };
 
   if (HAL_CAN_ConfigFilter(hcan, &allow_all) != HAL_OK) {
-    error();
+    return APP_NOT_OK;
   }
+
+  return APP_OK;
 }
 
 /**

--- a/libs/can-kingdom/include/mayor.h
+++ b/libs/can-kingdom/include/mayor.h
@@ -204,6 +204,11 @@ ck_err_t ck_send_mayors_page(uint8_t page_no);
  ******************************************************************************/
 ck_err_t ck_is_kings_envelope(ck_envelope_t *envelope);
 
+/*******************************************************************************
+ * Returns the current base number.
+ ******************************************************************************/
+uint32_t ck_get_base_number(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libs/can-kingdom/include/mayor.h
+++ b/libs/can-kingdom/include/mayor.h
@@ -195,12 +195,12 @@ ck_err_t ck_send_document(uint8_t folder_no);
 ck_err_t ck_send_mayors_page(uint8_t page_no);
 
 /*******************************************************************************
- * Checks if the envelope is from the king.
+ * Checks if the envelope is assigned to the king's folder
  *
  * @param envelope envelope to check.
  *
- * @return #CK_ERR_INVALID_KINGS_LETTER if it's not a king's envelope.
- * @return #CK_OK if it's a king's envelope.
+ * @return #CK_ERR_FALSE if it's not assigned.
+ * @return #CK_OK if it's assigned.
  ******************************************************************************/
 ck_err_t ck_is_kings_envelope(ck_envelope_t *envelope);
 

--- a/libs/can-kingdom/include/postmaster.h
+++ b/libs/can-kingdom/include/postmaster.h
@@ -43,6 +43,13 @@ ck_err_t ck_send_letter(const ck_letter_t *letter, uint8_t dlc);
  ******************************************************************************/
 ck_err_t ck_set_comm_mode(ck_comm_mode_t mode);
 
+/*******************************************************************************
+ * Get the currently set communication mode.
+ *
+ * @return ck_comm_mode_t containing the current mode.
+ ******************************************************************************/
+ck_comm_mode_t ck_get_comm_mode(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libs/can-kingdom/include/types.h
+++ b/libs/can-kingdom/include/types.h
@@ -179,25 +179,25 @@ typedef enum {
 /// Action mode as defined by the CAN Kingdom specification.
 typedef enum {
   /// Keep the current mode.
-  CK_ACTION_MODE_KEEP_CURRENT = 0x00,
+  CK_ACTION_MODE_KEEP_CURRENT = 0x0,
   /// Start the city.
-  CK_ACTION_MODE_RUN = 0x01,
+  CK_ACTION_MODE_RUN = 0x1,
   /// Stop the city.
-  CK_ACTION_MODE_FREEZE = 0x10,
+  CK_ACTION_MODE_FREEZE = 0x2,
   /// Reset the city.
-  CK_ACTION_MODE_RESET = 0x11,
+  CK_ACTION_MODE_RESET = 0x3,
 } ck_action_mode_t;
 
 /// Communication mode as defined by the CAN Kingdom specification.
 typedef enum {
   /// Keep the current mode.
-  CK_COMM_MODE_KEEP_CURRENT = 0x00,
+  CK_COMM_MODE_KEEP_CURRENT = 0x0,
   /// Set the CAN controller in silent mode.
-  CK_COMM_MODE_SILENT = 0x01,
+  CK_COMM_MODE_SILENT = 0x1,
   /// Set the CAN controller in listen-only mode.
-  CK_COMM_MODE_LISTEN_ONLY = 0x10,
+  CK_COMM_MODE_LISTEN_ONLY = 0x2,
   /// Enable CAN communication.
-  CK_COMM_MODE_COMMUNICATE = 0x11,
+  CK_COMM_MODE_COMMUNICATE = 0x3,
 } ck_comm_mode_t;
 
 /// Only #CK_CITY_MODE_KEEP_CURRENT is defined, the rest is defined by the user.

--- a/libs/can-kingdom/include/types.h
+++ b/libs/can-kingdom/include/types.h
@@ -160,6 +160,8 @@ typedef enum {
   CK_ERR_SEND_FAILED,
   /// Returned when setting a mode fails.
   CK_ERR_SET_MODE_FAILED,
+  /// Error code from boolean return type functions
+  CK_ERR_FALSE,
 } ck_err_t;
 
 /// Supported king's pages.

--- a/libs/can-kingdom/src/mayor.c
+++ b/libs/can-kingdom/src/mayor.c
@@ -70,6 +70,14 @@ ck_err_t ck_mayor_init(const ck_mayor_t *mayor_) {
     return CK_ERR_INVALID_PARAMETER;
   }
 
+  // Base number bounds check
+  if ((!mayor_->has_extended_id &&
+       mayor_->base_no + mayor_->city_address > CK_CAN_MAX_STD_ID) ||
+      (mayor_->has_extended_id &&
+       mayor_->base_no + mayor_->city_address > CK_CAN_MAX_EXT_ID)) {
+    return CK_ERR_INVALID_PARAMETER;
+  }
+
   // Copy user data to internal state.
   // Needs to be done before setting up the internal state.
   memcpy(&mayor.user_data, mayor_, sizeof(ck_mayor_t));

--- a/libs/can-kingdom/src/mayor.c
+++ b/libs/can-kingdom/src/mayor.c
@@ -137,6 +137,9 @@ ck_err_t ck_add_mayors_page(ck_page_t *page) {
 }
 
 ck_err_t ck_send_document(uint8_t folder_no) {
+  if (ck_get_comm_mode() != CK_COMM_MODE_COMMUNICATE) {
+    return CK_OK;
+  }
   int folder_index = find_folder(folder_no);
   if (folder_index < 0) {
     return CK_ERR_ITEM_NOT_FOUND;
@@ -179,6 +182,10 @@ ck_err_t ck_send_document(uint8_t folder_no) {
 }
 
 ck_err_t ck_send_mayors_page(uint8_t page_no) {
+  // Mayor's page should be sent in listen only mode and communicate mode.
+  if (ck_get_comm_mode() == CK_COMM_MODE_SILENT) {
+    return CK_OK;
+  }
   ck_folder_t *folder = &mayor.user_data.folders[CK_MAYORS_FOLDER_NO];
   // If folder is disabled or is a receive folder, return OK.
   if (!folder->enable || folder->direction != CK_DIRECTION_TRANSMIT) {
@@ -209,7 +216,7 @@ ck_err_t ck_send_mayors_page(uint8_t page_no) {
 ck_err_t ck_is_kings_envelope(ck_envelope_t *envelope) {
   ck_folder_t *folder = &mayor.user_data.folders[CK_KINGS_FOLDER_NO];
   if (find_envelope(folder, envelope) < 0) {
-    return CK_ERR_INVALID_KINGS_LETTER;
+    return CK_ERR_FALSE;
   }
 
   return CK_OK;

--- a/libs/can-kingdom/src/mayor.c
+++ b/libs/can-kingdom/src/mayor.c
@@ -230,6 +230,8 @@ ck_err_t ck_is_kings_envelope(ck_envelope_t *envelope) {
   return CK_OK;
 }
 
+uint32_t ck_get_base_number(void) { return mayor.user_data.base_no; }
+
 static void init_mayors_pages(void) {
   // Init mayor's pages
   mayor.pages[0].line_count = CK_MAX_LINES_PER_PAGE;

--- a/libs/can-kingdom/src/postmaster-dummy.c
+++ b/libs/can-kingdom/src/postmaster-dummy.c
@@ -14,3 +14,5 @@ ck_err_t ck_set_comm_mode(ck_comm_mode_t mode) {
   }
   return CK_OK;
 }
+
+ck_comm_mode_t ck_get_comm_mode(void) { return CK_COMM_MODE_COMMUNICATE; }

--- a/libs/can-kingdom/tests/mayor-test.c
+++ b/libs/can-kingdom/tests/mayor-test.c
@@ -102,8 +102,8 @@ static test_err_t test_mayor_init(void) {
   ck_mayor_t mayor = {
       .ean_no = illegal_ean_no,  // Illegal EAN
       .serial_no = test_serial_no,
-      .city_address = 0,  // illegal city address
-      .base_no = test_base_no,
+      .city_address = 0,             // Illegal city address
+      .base_no = CK_CAN_MAX_STD_ID,  // Illegal base no
       .has_extended_id = false,
       // Illegal function pointers
       .set_action_mode = NULL,
@@ -127,6 +127,12 @@ static test_err_t test_mayor_init(void) {
   }
 
   mayor.city_address = test_city_address;
+  if (ck_mayor_init(&mayor) == CK_OK) {
+    printf("mayor_init: illegal parameter returned OK.\n");
+    return TEST_FAIL;
+  }
+
+  mayor.base_no = test_base_no;
   if (ck_mayor_init(&mayor) == CK_OK) {
     printf("mayor_init: illegal parameter returned OK.\n");
     return TEST_FAIL;

--- a/libs/stm32-common/src/flash.c
+++ b/libs/stm32-common/src/flash.c
@@ -14,19 +14,19 @@
  * before first time use, which is why we write the FLASH_ERASED_SYMBOL.
  */
 int flash_init(void) {
-  uint32_t flashErased = 0;
-  if (flash_read(FLASH_RW_END - sizeof(flashErased), &flashErased,
-                 sizeof(flashErased)) != APP_OK) {
+  uint32_t flash_erased = 0;
+  if (flash_read(FLASH_RW_END - sizeof(flash_erased), &flash_erased,
+                 sizeof(flash_erased)) != APP_OK) {
     return APP_NOT_OK;
   }
   // Check if flash is already erased
-  if (flashErased == FLASH_ERASED_SYMBOL) {
+  if (flash_erased == FLASH_ERASED_SYMBOL) {
     return APP_OK;
   }
   flash_erase();
-  flashErased = FLASH_ERASED_SYMBOL;
-  if (flash_write(FLASH_RW_END - sizeof(uint32_t), &flashErased,
-                  sizeof(flashErased)) != APP_OK) {
+  flash_erased = FLASH_ERASED_SYMBOL;
+  if (flash_write(FLASH_RW_END - sizeof(uint32_t), &flash_erased,
+                  sizeof(flash_erased)) != APP_OK) {
     return APP_NOT_OK;
   }
   return APP_OK;
@@ -34,14 +34,14 @@ int flash_init(void) {
 
 int flash_erase(void) {
   // 1 page = 2KB
-  FLASH_EraseInitTypeDef eraseConf = {
+  FLASH_EraseInitTypeDef erase_conf = {
       .TypeErase = FLASH_TYPEERASE_PAGES,
       .PageAddress = FLASH_RW_START,
       .NbPages = 1,
   };
   HAL_FLASH_Unlock();
   uint32_t err = 0;
-  HAL_FLASHEx_Erase(&eraseConf, &err);
+  HAL_FLASHEx_Erase(&erase_conf, &err);
   HAL_FLASH_Lock();
   if (err != FLASH_ERASE_OK) {
     return APP_NOT_OK;
@@ -74,11 +74,11 @@ int flash_write(uint32_t addr, const void *data, size_t len) {
     return APP_NOT_OK;
   }
 
-  const size_t wordLength = 4;
+  const size_t word_length = 4;
   uint32_t word = 0;
   HAL_FLASH_Unlock();
-  for (size_t i = 0; i < len; i += wordLength) {
-    memcpy(&word, (uint8_t *)data + i, wordLength);
+  for (size_t i = 0; i < len; i += word_length) {
+    memcpy(&word, (uint8_t *)data + i, word_length);
     HAL_FLASH_Program(FLASH_TYPEPROGRAM_WORD, addr + i, (uint64_t)word);
   }
   HAL_FLASH_Lock();

--- a/libs/stm32-postmaster/include/postmaster-hal.h
+++ b/libs/stm32-postmaster/include/postmaster-hal.h
@@ -11,9 +11,6 @@ extern "C" {
 void postmaster_init(CAN_HandleTypeDef *hcan);
 CAN_HandleTypeDef *get_can_handle(void);
 
-ck_comm_mode_t get_comm_mode(void);
-void set_comm_mode(ck_comm_mode_t mode);
-
 #ifdef __cplusplus
 }
 #endif

--- a/libs/stm32-postmaster/src/postmaster-hal.c
+++ b/libs/stm32-postmaster/src/postmaster-hal.c
@@ -1,11 +1,7 @@
 #include "postmaster-hal.h"
 
 static CAN_HandleTypeDef *hcan;
-static ck_comm_mode_t comm_mode;
 
 void postmaster_init(CAN_HandleTypeDef *_hcan) { hcan = _hcan; }
 
 CAN_HandleTypeDef *get_can_handle(void) { return hcan; }
-
-ck_comm_mode_t get_comm_mode(void) { return comm_mode; }
-void set_comm_mode(ck_comm_mode_t mode) { comm_mode = mode; }

--- a/libs/stm32-postmaster/src/postmaster.c
+++ b/libs/stm32-postmaster/src/postmaster.c
@@ -2,6 +2,8 @@
 
 #include "postmaster-hal.h"
 
+static ck_comm_mode_t comm_mode;
+
 ck_err_t ck_send_letter(const ck_letter_t *letter, uint8_t dlc) {
   CAN_HandleTypeDef *hcan = get_can_handle();
 
@@ -48,7 +50,7 @@ ck_err_t ck_set_comm_mode(ck_comm_mode_t mode) {
   switch (mode) {
     case CK_COMM_MODE_COMMUNICATE:
     case CK_COMM_MODE_LISTEN_ONLY:
-      set_comm_mode(mode);
+      comm_mode = mode;
 
       if (HAL_CAN_GetState(hcan) == HAL_CAN_STATE_LISTENING) {
         if (HAL_CAN_Stop(hcan) != HAL_OK) {
@@ -68,7 +70,7 @@ ck_err_t ck_set_comm_mode(ck_comm_mode_t mode) {
       break;
 
     case CK_COMM_MODE_SILENT:
-      set_comm_mode(mode);
+      comm_mode = mode;
 
       if (HAL_CAN_GetState(hcan) == HAL_CAN_STATE_LISTENING) {
         if (HAL_CAN_Stop(hcan) != HAL_OK) {
@@ -92,3 +94,5 @@ ck_err_t ck_set_comm_mode(ck_comm_mode_t mode) {
   }
   return CK_OK;
 }
+
+ck_comm_mode_t ck_get_comm_mode(void) { return comm_mode; }

--- a/scripts/ck-startup.py
+++ b/scripts/ck-startup.py
@@ -1,0 +1,18 @@
+from canlib import canlib, Frame
+
+with canlib.openChannel(channel=0, flags=canlib.Open.REQUIRE_INIT_ACCESS, bitrate=canlib.Bitrate.BITRATE_125K) as ch:
+    ch.setBusOutputControl(canlib.Driver.NORMAL)
+    ch.busOn()
+    default_letter = Frame(id_=2031, data=[0xAA,0xAA,0xAA,0xAA,0xAA,0xAA,0xAA,0xAA])
+    kp0 = Frame(id_=0, dlc=8, data=[0,0,0,0x3,0,0,0,0]) # Set communication mode to COMMUNICATE
+    kp1 = Frame(id_=0, dlc=8, data=[0,1,0,0,0,2,0,0]) # Give base number and ask for response page 0
+    kp2_0 = Frame(id_=0, dlc=8, data=[0,2,2,0,0,0,2,0x3]) # Assign envelope 2 to folder 2
+    kp2_1 = Frame(id_=0, dlc=8, data=[0,2,3,0,0,0,3,0x3]) # Assign envelope 3 to folder 3
+    kp2_2 = Frame(id_=0, dlc=8, data=[0,2,4,0,0,0,4,0x3]) # Assign envelope 4 to folder 4
+
+    ch.writeWait(default_letter, -1)
+    ch.writeWait(kp1, -1)
+    ch.writeWait(kp2_0, -1)
+    ch.writeWait(kp2_1, -1)
+    ch.writeWait(kp2_2, -1)
+    ch.writeWait(kp0, -1)


### PR DESCRIPTION
- fix(can-kingdom): correct bit values for action and comm modes
- feat(can-kingdom): add ck_get_comm_mode() function
- fix(can-kingdom): verify base number in ck_mayor_init()
- feat(can-kingdom): allow fetching current base number
- chore(flash): rename to snake case
- feat(battery): go on bus using silent mode
- feat(battery): receive default letter
- feat(battery): handle startup sequence
- feat(battery): king support
- feat(scripts): add script for king emulation
