### PR TITLE
feat/add kp8

### DIFF
--- a/apps/battery-node/include/peripherals.h
+++ b/apps/battery-node/include/peripherals.h
@@ -23,17 +23,10 @@ typedef struct {
   UART_HandleTypeDef huart1;
 } peripherals_t;
 
-typedef struct {
-  uint8_t prescaler;
-  uint8_t tseg1;
-  uint8_t tseg2;
-  uint8_t sjw;
-} can_bit_timing_t;
-
 peripherals_t *get_peripherals(void);
 void adc1_init(void);
 void adc2_init(void);
-int can_init(can_bit_timing_t *bit_timing);
+void can_init(void);
 void i2c1_init(void);
 void spi1_init(void);
 void uart1_init(void);

--- a/apps/battery-node/src/main.c
+++ b/apps/battery-node/src/main.c
@@ -416,7 +416,7 @@ void HAL_CAN_RxFifo0MsgPendingCallback(CAN_HandleTypeDef *hcan) {
 }
 
 bool is_default_letter(ck_letter_t *letter) {
-  ck_letter_t dletter = default_letter();
+  ck_letter_t dletter = ck_default_letter();
   if (letter->envelope.envelope_no == dletter.envelope.envelope_no &&
       letter->page.line_count == dletter.page.line_count &&
       memcmp(letter->page.lines, dletter.page.lines, dletter.page.line_count) ==

--- a/apps/battery-node/src/main.c
+++ b/apps/battery-node/src/main.c
@@ -350,6 +350,7 @@ ck_letter_t frame_to_letter(CAN_RxHeaderTypeDef *header, uint8_t *data) {
   } else {
     letter.envelope.envelope_no = header->StdId;
   }
+  letter.envelope.is_compressed = false;
   letter.page.line_count = header->DLC;
   memcpy(letter.page.lines, data, header->DLC);
   return letter;

--- a/apps/battery-node/src/peripherals.c
+++ b/apps/battery-node/src/peripherals.c
@@ -169,118 +169,14 @@ void adc2_init(void) {
  * @param None
  * @retval None
  */
-int can_init(can_bit_timing_t* bit_timing) {
+void can_init(void) {
   CAN_HandleTypeDef* hcan = &peripherals.hcan;
   hcan->Instance = CAN;
-
-  if (bit_timing->prescaler < 1) {
-    return APP_NOT_OK;
-  }
-
-  hcan->Init.Prescaler = bit_timing->prescaler;
   hcan->Init.Mode = CAN_MODE_NORMAL;
-
-  switch (bit_timing->sjw) {
-    case 1:
-      hcan->Init.SyncJumpWidth = CAN_SJW_1TQ;
-      break;
-    case 2:
-      hcan->Init.SyncJumpWidth = CAN_SJW_2TQ;
-      break;
-    case 3:
-      hcan->Init.SyncJumpWidth = CAN_SJW_3TQ;
-      break;
-    case 4:
-      hcan->Init.SyncJumpWidth = CAN_SJW_4TQ;
-      break;
-    default:
-      return APP_NOT_OK;
-  }
-
-  // NOLINTBEGIN(*-magic-numbers)
-  switch (bit_timing->tseg1) {
-    case 1:
-      hcan->Init.TimeSeg1 = CAN_BS1_1TQ;
-      break;
-    case 2:
-      hcan->Init.TimeSeg1 = CAN_BS1_2TQ;
-      break;
-    case 3:
-      hcan->Init.TimeSeg1 = CAN_BS1_3TQ;
-      break;
-    case 4:
-      hcan->Init.TimeSeg1 = CAN_BS1_4TQ;
-      break;
-    case 5:
-      hcan->Init.TimeSeg1 = CAN_BS1_5TQ;
-      break;
-    case 6:
-      hcan->Init.TimeSeg1 = CAN_BS1_6TQ;
-      break;
-    case 7:
-      hcan->Init.TimeSeg1 = CAN_BS1_7TQ;
-      break;
-    case 8:
-      hcan->Init.TimeSeg1 = CAN_BS1_8TQ;
-      break;
-    case 9:
-      hcan->Init.TimeSeg1 = CAN_BS1_9TQ;
-      break;
-    case 10:
-      hcan->Init.TimeSeg1 = CAN_BS1_10TQ;
-      break;
-    case 11:
-      hcan->Init.TimeSeg1 = CAN_BS1_11TQ;
-      break;
-    case 12:
-      hcan->Init.TimeSeg1 = CAN_BS1_12TQ;
-      break;
-    case 13:
-      hcan->Init.TimeSeg1 = CAN_BS1_13TQ;
-      break;
-    case 14:
-      hcan->Init.TimeSeg1 = CAN_BS1_14TQ;
-      break;
-    case 15:
-      hcan->Init.TimeSeg1 = CAN_BS1_15TQ;
-      break;
-    case 16:
-      hcan->Init.TimeSeg1 = CAN_BS1_16TQ;
-      break;
-    default:
-      return APP_NOT_OK;
-  }
-
-  switch (bit_timing->tseg2) {
-    case 1:
-      hcan->Init.TimeSeg2 = CAN_BS2_1TQ;
-      break;
-    case 2:
-      hcan->Init.TimeSeg2 = CAN_BS2_2TQ;
-      break;
-    case 3:
-      hcan->Init.TimeSeg2 = CAN_BS2_3TQ;
-      break;
-    case 4:
-      hcan->Init.TimeSeg2 = CAN_BS2_4TQ;
-      break;
-    case 5:
-      hcan->Init.TimeSeg2 = CAN_BS2_5TQ;
-      break;
-    case 6:
-      hcan->Init.TimeSeg2 = CAN_BS2_6TQ;
-      break;
-    case 7:
-      hcan->Init.TimeSeg2 = CAN_BS2_7TQ;
-      break;
-    case 8:
-      hcan->Init.TimeSeg2 = CAN_BS2_8TQ;
-      break;
-    default:
-      return APP_NOT_OK;
-  }
-  // NOLINTEND(*-magic-numbers)
-
+  hcan->Init.Prescaler = 18;  // NOLINT
+  hcan->Init.TimeSeg1 = CAN_BS1_13TQ;
+  hcan->Init.TimeSeg2 = CAN_BS2_2TQ;
+  hcan->Init.SyncJumpWidth = CAN_SJW_1TQ;
   hcan->Init.TimeTriggeredMode = DISABLE;
   hcan->Init.AutoBusOff = DISABLE;
   hcan->Init.AutoWakeUp = DISABLE;
@@ -288,7 +184,7 @@ int can_init(can_bit_timing_t* bit_timing) {
   hcan->Init.ReceiveFifoLocked = DISABLE;
   hcan->Init.TransmitFifoPriority = DISABLE;
   if (HAL_CAN_Init(hcan) != HAL_OK) {
-    return APP_NOT_OK;
+    error();
   }
 
   CAN_FilterTypeDef allow_all = {
@@ -304,10 +200,8 @@ int can_init(can_bit_timing_t* bit_timing) {
   };
 
   if (HAL_CAN_ConfigFilter(hcan, &allow_all) != HAL_OK) {
-    return APP_NOT_OK;
+    error();
   }
-
-  return APP_OK;
 }
 
 /**

--- a/libs/can-kingdom/include/king.h
+++ b/libs/can-kingdom/include/king.h
@@ -154,6 +154,21 @@ ck_err_t ck_create_kings_page_1(const ck_kp1_args_t *args, ck_page_t *page);
 ck_err_t ck_create_kings_page_2(const ck_kp2_args_t *args, ck_page_t *page);
 
 /*******************************************************************************
+ * KP8 is used to set the CAN bit timing settings for a city.
+ *
+ * @param address city or group address.
+ * @param args ck_can_bit_timing_t with the desired values.
+ * @param page will be populated with the created king's page.
+ *
+ * @return #CK_ERR_INCOMPATIBLE_PARAMS if some of the args are incompatible.
+ * @return #CK_ERR_INVALID_CAN_ID if the given CAN ID is out of bounds.
+ * @return #CK_OK on success.
+ *******************************************************************************/
+ck_err_t ck_create_kings_page_8(uint8_t address,
+                                const ck_can_bit_timing_t *bit_timing,
+                                ck_page_t *page);
+
+/*******************************************************************************
  * KP16 Sets the folder label and/or places a document into a folder.
  *
  * @param args ck_kp16_args_t value with the desired values.

--- a/libs/can-kingdom/include/king.h
+++ b/libs/can-kingdom/include/king.h
@@ -26,6 +26,8 @@ typedef struct {
   ck_action_mode_t action_mode;
   /// Communication mode.
   ck_comm_mode_t comm_mode;
+  /// Communication mode flags to set.
+  ck_comm_flags_t comm_flags;
   /// City mode. Only #CK_CITY_MODE_KEEP_CURRENT is predefined. Modes are
   /// defined by mayor and specified in their city's documentation.
   ck_city_mode_t city_mode;

--- a/libs/can-kingdom/include/mayor.h
+++ b/libs/can-kingdom/include/mayor.h
@@ -205,6 +205,23 @@ ck_err_t ck_send_mayors_page(uint8_t page_no);
 ck_err_t ck_is_kings_envelope(ck_envelope_t *envelope);
 
 /*******************************************************************************
+ * Set the communication mode.
+ *
+ * @param mode the desired communication mode.
+ *
+ * @return #CK_OK on success.
+ * @return #CK_ERR_SET_MODE_FAILED if failed setting the communication mode.
+ * @return #CK_ERR_INVALID_COMM_MODE if the requested communication mode is
+ *         invalid.
+ ******************************************************************************/
+ck_err_t ck_set_comm_mode(ck_comm_mode_t mode);
+
+/*******************************************************************************
+ * Return the currently set communication mode.
+ ******************************************************************************/
+ck_comm_mode_t ck_get_comm_mode(void);
+
+/*******************************************************************************
  * Returns the current base number.
  ******************************************************************************/
 uint32_t ck_get_base_number(void);

--- a/libs/can-kingdom/include/mayor.h
+++ b/libs/can-kingdom/include/mayor.h
@@ -140,7 +140,7 @@ ck_err_t ck_mayor_init(const ck_mayor_t *mayor);
  *         type.
  *
  * @return #CK_ERR_INVALID_PARAMETER some parameters on the king's page are
- *         invalid.
+ *         invalid, or the passed letter is NULL.
  *
  * @return #CK_OK on success or if the letter is not addressed to the caller.
  ******************************************************************************/

--- a/libs/can-kingdom/include/postmaster.h
+++ b/libs/can-kingdom/include/postmaster.h
@@ -32,7 +32,8 @@ extern "C" {
 ck_err_t ck_send_letter(const ck_letter_t *letter, uint8_t dlc);
 
 /*******************************************************************************
- * Set the communication mode of the city.
+ * Apply the requested communication mode in hardware. This function shouldn't
+ * be called from user applications, use ck_set_comm_mode() instead.
  *
  * @param mode the desired communication mode.
  *
@@ -41,14 +42,7 @@ ck_err_t ck_send_letter(const ck_letter_t *letter, uint8_t dlc);
  * @return #CK_ERR_INVALID_COMM_MODE if the requested communication mode is
  *         invalid.
  ******************************************************************************/
-ck_err_t ck_set_comm_mode(ck_comm_mode_t mode);
-
-/*******************************************************************************
- * Get the currently set communication mode.
- *
- * @return ck_comm_mode_t containing the current mode.
- ******************************************************************************/
-ck_comm_mode_t ck_get_comm_mode(void);
+ck_err_t ck_apply_comm_mode(ck_comm_mode_t mode);
 
 #ifdef __cplusplus
 }

--- a/libs/can-kingdom/include/postmaster.h
+++ b/libs/can-kingdom/include/postmaster.h
@@ -51,7 +51,7 @@ ck_err_t ck_apply_comm_mode(ck_comm_mode_t mode);
 
 /*******************************************************************************
  * Return the ck_can_bit_timing_t prescaler that will give a bit rate of
- * 125 kbit/s on the target hardware.
+ * 125 Kbit/s on the target hardware.
  ******************************************************************************/
 uint8_t ck_get_125kbit_prescaler(void);
 

--- a/libs/can-kingdom/include/postmaster.h
+++ b/libs/can-kingdom/include/postmaster.h
@@ -4,6 +4,9 @@
  * The postmaster is responsible for handling CAN communication in a city. The
  * postmaster implementation is hardware dependent. This header file contains
  * the interface that needs to be fulfilled by the implementation.
+ *
+ * For all functions, the specified return codes should be provided by the
+ * implementation.
  ******************************************************************************/
 
 #ifndef CK_POSTMASTER_H
@@ -32,17 +35,64 @@ extern "C" {
 ck_err_t ck_send_letter(const ck_letter_t *letter, uint8_t dlc);
 
 /*******************************************************************************
- * Apply the requested communication mode in hardware. This function shouldn't
- * be called from user applications, use ck_set_comm_mode() instead.
+ * Apply the requested communication mode in hardware.
+ *
+ * This function shouldn't be called directly by the user application, use
+ * ck_set_comm_mode() instead.
  *
  * @param mode the desired communication mode.
  *
- * @return #CK_OK on success.
  * @return #CK_ERR_SET_MODE_FAILED if failed setting the communication mode.
  * @return #CK_ERR_INVALID_COMM_MODE if the requested communication mode is
  *         invalid.
+ * @return #CK_OK on success.
  ******************************************************************************/
 ck_err_t ck_apply_comm_mode(ck_comm_mode_t mode);
+
+/*******************************************************************************
+ * Return the ck_can_bit_timing_t prescaler that will give a bit rate of
+ * 125 kbit/s on the target hardware.
+ ******************************************************************************/
+uint8_t ck_get_125kbit_prescaler(void);
+
+/*******************************************************************************
+ * Set the given bit timing parameters for CAN communication.
+ *
+ * This function must never apply invalid CAN settings on the peripheral. Doing
+ * so will make the city unable to communicate. At the very least, in the event
+ * of bad settings, the hardware should revert to the old settings.
+ *
+ * @param bit_timing the requested ck_can_bit_timing_t.
+ *
+ * @return #CK_ERR_INVALID_CAN_BIT_TIMING if the bit_timing is incompatible with
+ *         the target hardware.
+ *
+ * @return #CK_ERR_PERIPHERAL if setting the bit_timing failed for some other
+ *         reason.
+ *
+ * @return #CK_OK on success
+ ******************************************************************************/
+ck_err_t ck_set_bit_timing(const ck_can_bit_timing_t *bit_timing);
+
+/*******************************************************************************
+ * Save the given bit_timing parameters to persistent storage.
+ *
+ * @param bit_timing the ck_can_bit_timing_t to save.
+ *
+ * @return #CK_ERR_PERIPHERAL if it wasn't possible to save the parameters.
+ * @return #CK_OK on success
+ ******************************************************************************/
+ck_err_t ck_save_bit_timing(const ck_can_bit_timing_t *bit_timing);
+
+/*******************************************************************************
+ * Load a bit timing parameters from persistent storage.
+ *
+ * @param bit_timing the loaded bit timing parameters.
+ *
+ * @return #CK_ERR_PERIPHERAL if it wasn't possible to load the parameters.
+ * @return #CK_OK on success
+ ******************************************************************************/
+ck_err_t ck_load_bit_timing(ck_can_bit_timing_t *bit_timing);
 
 #ifdef __cplusplus
 }

--- a/libs/can-kingdom/include/types.h
+++ b/libs/can-kingdom/include/types.h
@@ -132,6 +132,8 @@ typedef enum {
   CK_ERR_INVALID_CAN_ID,
   /// Invalid CAN DLC.
   CK_ERR_INVALID_CAN_DLC,
+  /// Invalid ck_can_bit_timing_t.
+  CK_ERR_INVALID_CAN_BIT_TIMING,
   /// Invalid King's letter.
   CK_ERR_INVALID_KINGS_LETTER,
   /// Unsupported King's page.
@@ -146,8 +148,6 @@ typedef enum {
   CK_ERR_INVALID_COMM_MODE,
   /// Invalid #ck_list_type_t.
   CK_ERR_INVALID_LIST_TYPE,
-  /// Input argument to function is wrong in some way.
-  CK_ERR_INVALID_PARAMETER,
   /// Missing input argument to function.
   CK_ERR_MISSING_PARAMETER,
   /// List, folder, document or page is full.
@@ -162,6 +162,10 @@ typedef enum {
   CK_ERR_SET_MODE_FAILED,
   /// Error code from boolean return type functions
   CK_ERR_FALSE,
+  /// Failed to access some peripheral.
+  CK_ERR_PERIPHERAL,
+  /// Input argument to function is wrong in some way.
+  CK_ERR_INVALID_PARAMETER,
 } ck_err_t;
 
 /// Supported king's pages.
@@ -373,6 +377,31 @@ typedef enum {
   /// replace the old document with the new one.
   CK_DOCUMENT_INSERT = 3,
 } ck_document_action_t;
+
+/*******************************************************************************
+ * Defines the CAN bit timing parameters needed to set the postoffice settings.
+ *
+ * The value of Phase segment 1 + propagation segment will be inferred from the
+ * following equation: `time_quanta = 1 + prop_seg + phase_seg1 + phase_seg2`,
+ * where `8 <= time_quanta <= 25` and `2 <= phase_seg2 <= 8`.
+ ******************************************************************************/
+typedef struct {
+  /// Defines the clock prescaler, which will determine the bit rate. It's
+  /// important to know the clock frequency of the CAN peripheral to set the
+  /// correct bit rate.
+  ///
+  /// `1 <= prescaler <= 32`
+  uint8_t prescaler;
+
+  uint8_t time_quanta;  /// Number of time quanta.
+
+  uint8_t phase_seg2;  /// Phase segment 2.
+
+  /// Synchronization jump width, `1 <= sjw <= 4`. Must also be less than the
+  /// minimum of phase_seg1 and phase_seg2.
+  uint8_t sjw;
+
+} ck_can_bit_timing_t;
 
 /*******************************************************************************
  * Check if the specified action mode is a valid action mode.

--- a/libs/can-kingdom/include/types.h
+++ b/libs/can-kingdom/include/types.h
@@ -397,7 +397,7 @@ ck_err_t ck_check_list_type(ck_list_type_t type);
  *
  * @return the created letter.
  ******************************************************************************/
-ck_letter_t default_letter(void);
+ck_letter_t ck_default_letter(void);
 
 #ifdef __cplusplus
 }

--- a/libs/can-kingdom/include/types.h
+++ b/libs/can-kingdom/include/types.h
@@ -176,6 +176,8 @@ typedef enum {
   CK_KP1 = 1,
   /// King's page 2.
   CK_KP2 = 2,
+  /// King's page 8.
+  CK_KP8 = 8,
   /// King's page 16.
   CK_KP16 = 16,
   /// King's page 17.

--- a/libs/can-kingdom/include/types.h
+++ b/libs/can-kingdom/include/types.h
@@ -202,6 +202,21 @@ typedef enum {
   CK_COMM_MODE_COMMUNICATE = 0x3,
 } ck_comm_mode_t;
 
+/// Communication mode flags, used in KP0.
+typedef enum {
+  /// Reset communication by going through the startup sequence with new bit
+  /// timing settings.
+  CK_COMM_RESET = 0x4,
+  /// Skip listening for a good message during startup sequence.
+  CK_COMM_SKIP_LISTEN = 0x8,
+  /// Don't skip listening for a good message during startup sequence.
+  CK_COMM_DONT_SKIP_LISTEN = 0x10,
+  /// Skip 200ms wait for default letter during startup sequence.
+  CK_COMM_SKIP_WAIT = 0x20,
+  /// Don't 200ms wait for default letter during startup sequence.
+  CK_COMM_DONT_SKIP_WAIT = 0x40,
+} ck_comm_flags_t;
+
 /// Only #CK_CITY_MODE_KEEP_CURRENT is defined, the rest is defined by the user.
 typedef enum {
   /// Keep the current mode.

--- a/libs/can-kingdom/include/types.h
+++ b/libs/can-kingdom/include/types.h
@@ -434,7 +434,22 @@ ck_err_t ck_check_comm_mode(ck_comm_mode_t mode);
 ck_err_t ck_check_list_type(ck_list_type_t type);
 
 /*******************************************************************************
- * Creates a CAN Kingdom default letter.
+ * Check if the given ck_can_bit_timing_t is valid.
+ *
+ * The checking performed by the function relate to the CAN standard for what is
+ * allowed and what is not allowed. Some hardware may be able to set some values
+ * that this function will reject. In that case, the user will have to perform
+ * validation themselves.
+ *
+ * @param bit_timing pointer to parameters to check.
+ *
+ * @return #CK_ERR_INVALID_CAN_BIT_TIMING if bit_timing is invalid.
+ * @return #CK_OK on success.
+ ******************************************************************************/
+ck_err_t ck_check_can_bit_timing(const ck_can_bit_timing_t *bit_timing);
+
+/*******************************************************************************
+ * Returns a CAN Kingdom default letter.
  *
  * The default letter is a letter with CAN ID 2031 and 8 lines each containing
  * `0xAA`.
@@ -442,6 +457,14 @@ ck_err_t ck_check_list_type(ck_list_type_t type);
  * @return the created letter.
  ******************************************************************************/
 ck_letter_t ck_default_letter(void);
+
+/*******************************************************************************
+ * Returns bit timing parameters specifying a bit rate of 125 Kbit/s and a
+ * sampling point of 87.5%.
+ *
+ * @return the ck_can_bit_timing_t.
+ ******************************************************************************/
+ck_can_bit_timing_t ck_default_bit_timing(void);
 
 #ifdef __cplusplus
 }

--- a/libs/can-kingdom/src/king.c
+++ b/libs/can-kingdom/src/king.c
@@ -6,6 +6,10 @@
 // NOLINTBEGIN(*magic-numbers)
 
 ck_err_t ck_create_kings_page_0(const ck_kp0_args_t *args, ck_page_t *page) {
+  // Null pointer check
+  if (!args || !page) {
+    return CK_ERR_INVALID_PARAMETER;
+  }
   ck_err_t ret = ck_check_action_mode(args->action_mode);
   if (ret != CK_OK) {
     return ret;
@@ -27,6 +31,10 @@ ck_err_t ck_create_kings_page_0(const ck_kp0_args_t *args, ck_page_t *page) {
 }
 
 ck_err_t ck_create_kings_page_1(const ck_kp1_args_t *args, ck_page_t *page) {
+  // Null pointer check
+  if (!args || !page) {
+    return CK_ERR_INVALID_PARAMETER;
+  }
   // CAN ID bounds check
   if ((!args->has_extended_id && args->base_no > CK_CAN_MAX_STD_ID) ||
       (args->has_extended_id && args->base_no > CK_CAN_MAX_EXT_ID)) {
@@ -47,6 +55,10 @@ ck_err_t ck_create_kings_page_1(const ck_kp1_args_t *args, ck_page_t *page) {
 }
 
 ck_err_t ck_create_kings_page_2(const ck_kp2_args_t *args, ck_page_t *page) {
+  // Null pointer check
+  if (!args || !page) {
+    return CK_ERR_INVALID_PARAMETER;
+  }
   // CAN ID bounds check
   if ((!args->envelope.has_extended_id &&
        args->envelope.envelope_no > CK_CAN_MAX_STD_ID) ||
@@ -78,6 +90,10 @@ ck_err_t ck_create_kings_page_2(const ck_kp2_args_t *args, ck_page_t *page) {
 }
 
 ck_err_t ck_create_kings_page_16(const ck_kp16_args_t *args, ck_page_t *page) {
+  // Null pointer check
+  if (!args || !page) {
+    return CK_ERR_INVALID_PARAMETER;
+  }
   // Folders 0 and 1 are reserved for the king's document and the mayor's
   // document, respectively.
   if (args->folder_no < 2) {
@@ -120,6 +136,10 @@ ck_err_t ck_create_kings_page_16(const ck_kp16_args_t *args, ck_page_t *page) {
 }
 
 ck_err_t ck_create_kings_page_17(const ck_kp17_args_t *args, ck_page_t *page) {
+  // Null pointer check
+  if (!args || !page) {
+    return CK_ERR_INVALID_PARAMETER;
+  }
   ck_err_t ret = ck_check_list_type(args->list_type);
   if (ret != CK_OK) {
     return ret;

--- a/libs/can-kingdom/src/king.c
+++ b/libs/can-kingdom/src/king.c
@@ -89,6 +89,27 @@ ck_err_t ck_create_kings_page_2(const ck_kp2_args_t *args, ck_page_t *page) {
   return CK_OK;
 }
 
+ck_err_t ck_create_kings_page_8(uint8_t address,
+                                const ck_can_bit_timing_t *bit_timing,
+                                ck_page_t *page) {
+  // Null pointer check
+  if (!bit_timing | !page) {
+    return CK_ERR_INVALID_PARAMETER;
+  }
+
+  page->line_count = CK_MAX_LINES_PER_PAGE;
+  page->lines[0] = address;
+  page->lines[1] = CK_KP8;
+  page->lines[2] = 0;
+  page->lines[3] = 0;
+  page->lines[4] = bit_timing->prescaler;
+  page->lines[5] = bit_timing->time_quanta;
+  page->lines[6] = bit_timing->phase_seg2;
+  page->lines[7] = bit_timing->sjw;
+
+  return CK_OK;
+}
+
 ck_err_t ck_create_kings_page_16(const ck_kp16_args_t *args, ck_page_t *page) {
   // Null pointer check
   if (!args || !page) {

--- a/libs/can-kingdom/src/king.c
+++ b/libs/can-kingdom/src/king.c
@@ -22,7 +22,7 @@ ck_err_t ck_create_kings_page_0(const ck_kp0_args_t *args, ck_page_t *page) {
   page->lines[0] = args->address;
   page->lines[1] = CK_KP0;
   page->lines[2] = args->action_mode;
-  page->lines[3] = args->comm_mode;
+  page->lines[3] = args->comm_mode | args->comm_flags;
   page->lines[4] = args->city_mode;
   page->lines[5] = 0;
   page->lines[6] = 0;

--- a/libs/can-kingdom/src/mayor.c
+++ b/libs/can-kingdom/src/mayor.c
@@ -325,8 +325,10 @@ ck_err_t ck_set_base_number(uint32_t base_no, bool has_extended_id) {
   mayor.base_no_has_extended_id = has_extended_id;
   ck_envelope_t mayors_envelope = {
       .envelope_no = base_no + mayor.user_data.city_address,
-      .has_extended_id = has_extended_id,
       .enable = true,
+      .has_extended_id = has_extended_id,
+      .is_remote = false,
+      .is_compressed = false,
   };
   return assign_envelope(CK_MAYORS_FOLDER_NO, &mayors_envelope);
 }
@@ -569,8 +571,10 @@ static ck_err_t process_kp1(const ck_page_t *page) {
   if (mayor.base_no != base_no) {
     ck_envelope_t mayors_envelope = {
         .envelope_no = base_no + mayor.user_data.city_address,
-        .has_extended_id = extended_id,
         .enable = true,
+        .has_extended_id = extended_id,
+        .is_compressed = false,
+        .is_remote = false,
     };
 
     ck_err_t ret = assign_envelope(CK_MAYORS_FOLDER_NO, &mayors_envelope);
@@ -599,6 +603,7 @@ static ck_err_t process_kp2(const ck_page_t *page) {
   envelope.envelope_no &= CK_CAN_ID_MASK;
   envelope.has_extended_id = (page->lines[5] >> 7) & 0x01;
   envelope.is_compressed = (page->lines[5] >> 6) & 0x01;
+  envelope.is_remote = false;
 
   uint8_t folder_no = page->lines[6];
   envelope.enable = page->lines[7] & 0x01;

--- a/libs/can-kingdom/src/postmaster-dummy.c
+++ b/libs/can-kingdom/src/postmaster-dummy.c
@@ -1,5 +1,8 @@
 #include "postmaster.h"
 
+static ck_can_bit_timing_t current_bit_timing;
+static ck_can_bit_timing_t saved_bit_timing;
+
 ck_err_t ck_send_letter(const ck_letter_t *letter, uint8_t dlc) {
   (void)letter;
   if (dlc > CK_CAN_MAX_DLC) {
@@ -12,5 +15,31 @@ ck_err_t ck_apply_comm_mode(ck_comm_mode_t mode) {
   if (ck_check_comm_mode(mode) != CK_OK) {
     return CK_ERR_INVALID_COMM_MODE;
   }
+  return CK_OK;
+}
+
+uint8_t ck_get_125kbit_prescaler(void) { return 1; }
+
+ck_err_t ck_set_bit_timing(const ck_can_bit_timing_t *bit_timing) {
+  if (!bit_timing) {
+    return CK_ERR_INVALID_CAN_BIT_TIMING;
+  }
+  current_bit_timing = *bit_timing;
+  return CK_OK;
+}
+
+ck_err_t ck_save_bit_timing(const ck_can_bit_timing_t *bit_timing) {
+  if (!bit_timing) {
+    return CK_ERR_INVALID_CAN_BIT_TIMING;
+  }
+  saved_bit_timing = *bit_timing;
+  return CK_OK;
+}
+
+ck_err_t ck_load_bit_timing(ck_can_bit_timing_t *bit_timing) {
+  if (!bit_timing) {
+    return CK_ERR_INVALID_CAN_BIT_TIMING;
+  }
+  *bit_timing = saved_bit_timing;
   return CK_OK;
 }

--- a/libs/can-kingdom/src/postmaster-dummy.c
+++ b/libs/can-kingdom/src/postmaster-dummy.c
@@ -8,11 +8,9 @@ ck_err_t ck_send_letter(const ck_letter_t *letter, uint8_t dlc) {
   return CK_OK;
 }
 
-ck_err_t ck_set_comm_mode(ck_comm_mode_t mode) {
+ck_err_t ck_apply_comm_mode(ck_comm_mode_t mode) {
   if (ck_check_comm_mode(mode) != CK_OK) {
     return CK_ERR_INVALID_COMM_MODE;
   }
   return CK_OK;
 }
-
-ck_comm_mode_t ck_get_comm_mode(void) { return CK_COMM_MODE_COMMUNICATE; }

--- a/libs/can-kingdom/src/types.c
+++ b/libs/can-kingdom/src/types.c
@@ -36,7 +36,7 @@ ck_err_t ck_check_list_type(ck_list_type_t type) {
   }
 }
 
-ck_letter_t default_letter(void) {
+ck_letter_t ck_default_letter(void) {
   ck_letter_t letter = {
       .envelope =
           {

--- a/libs/can-kingdom/tests/king-test.c
+++ b/libs/can-kingdom/tests/king-test.c
@@ -10,24 +10,34 @@ static test_err_t verify_kp_header(int page_no, ck_page_t *page);
 static test_err_t test_kp0(void);
 static test_err_t test_kp1(void);
 static test_err_t test_kp2(void);
+static test_err_t test_kp8(void);
 static test_err_t test_kp16(void);
 static test_err_t test_kp17(void);
 
 int main(void) {
-  if (test_kp0() != TEST_PASS) {
-    return TEST_FAIL;
+  test_err_t ret = test_kp0();
+  if (ret != TEST_PASS) {
+    return ret;
   }
-  if (test_kp1() != TEST_PASS) {
-    return TEST_FAIL;
+  ret = test_kp1();
+  if (ret != TEST_PASS) {
+    return ret;
   }
-  if (test_kp2() != TEST_PASS) {
-    return TEST_FAIL;
+  ret = test_kp2();
+  if (ret != TEST_PASS) {
+    return ret;
   }
-  if (test_kp16() != TEST_PASS) {
-    return TEST_FAIL;
+  ret = test_kp8();
+  if (ret != TEST_PASS) {
+    return ret;
   }
-  if (test_kp17() != TEST_PASS) {
-    return TEST_FAIL;
+  ret = test_kp16();
+  if (ret != TEST_PASS) {
+    return ret;
+  }
+  ret = test_kp17();
+  if (ret != TEST_PASS) {
+    return ret;
   }
   return TEST_PASS;
 }
@@ -216,6 +226,18 @@ static test_err_t test_kp2(void) {
   memset(&page, 0, sizeof(page));
   if (ck_create_kings_page_2(&args, &page) != CK_ERR_INCOMPATIBLE_PARAMS) {
     printf("KP2: setting illegal parameter combination succeeded.\n");
+    return TEST_FAIL;
+  }
+
+  return TEST_PASS;
+}
+
+static test_err_t test_kp8(void) {
+  ck_page_t page;
+  ck_can_bit_timing_t default_bit_timing = ck_default_bit_timing();
+  if (ck_create_kings_page_8(test_city_address, &default_bit_timing, &page) !=
+      CK_OK) {
+    printf("KP8: failed to set default bit timing.\n");
     return TEST_FAIL;
   }
 

--- a/libs/can-kingdom/tests/king-test.c
+++ b/libs/can-kingdom/tests/king-test.c
@@ -38,6 +38,7 @@ static test_err_t test_kp0(void) {
       .address = test_city_address,
       .action_mode = CK_ACTION_MODE_RUN,
       .comm_mode = CK_COMM_MODE_COMMUNICATE,
+      .comm_flags = CK_COMM_SKIP_LISTEN | CK_COMM_SKIP_WAIT | CK_COMM_RESET,
       .city_mode = CK_CITY_MODE_KEEP_CURRENT,
   };
 
@@ -56,9 +57,14 @@ static test_err_t test_kp0(void) {
            page.lines[2]);
     return TEST_FAIL;
   }
-  if (page.lines[3] != args.comm_mode) {
+  if ((page.lines[3] & 0x3) != args.comm_mode) {
     printf("KP0: wrong comm mode, expected: %x, got: %x.\n", args.comm_mode,
-           page.lines[3]);
+           page.lines[3] & 0x3);
+    return TEST_FAIL;
+  }
+  if ((page.lines[3] & ~0x3) != args.comm_flags) {
+    printf("KP0: wrong flags set, expected: %x, got: %x.\n", args.comm_flags,
+           page.lines[3] & ~0x3);
     return TEST_FAIL;
   }
   if (page.lines[4] != args.city_mode) {

--- a/libs/can-kingdom/tests/mayor-test.c
+++ b/libs/can-kingdom/tests/mayor-test.c
@@ -369,8 +369,8 @@ static test_err_t test_process_kp1(void) {
   return TEST_PASS;
 }
 
-// First assign envelopes 2 and 3 to folder 2, then transfer envelope 3 to
-// folder 3, then expel envelope 2.
+// First assign envelopes 200 and 300 to folder 2, then transfer envelope 300 to
+// folder 3, then expel envelope 200.
 static test_err_t test_process_kp2(void) {
   test_err_t err = setup_test();
   if (err != TEST_PASS) {
@@ -382,8 +382,8 @@ static test_err_t test_process_kp2(void) {
   letter.page.lines[0] = test_city_address;
   letter.page.lines[1] = CK_KP2;
 
-  uint32_t envelope2 = 2;
-  uint32_t folder2 = 2;
+  const uint32_t envelope2 = 200;
+  const uint32_t folder2 = 2;
 
   memcpy(&letter.page.lines[2], &envelope2, sizeof(envelope2));
   // NOLINTBEGIN(*-magic-numbers)
@@ -412,7 +412,7 @@ static test_err_t test_process_kp2(void) {
   }
 
   // Assign envelope no 3 to folder no 2.
-  uint32_t envelope3 = 3;
+  const uint32_t envelope3 = 300;
   memcpy(&letter.page.lines[2], &envelope3, sizeof(envelope3));
   if (ck_process_kings_letter(&letter) != CK_OK) {
     printf("process_kp2: assign: failed to process page.\n");

--- a/libs/can-kingdom/tests/types-test.c
+++ b/libs/can-kingdom/tests/types-test.c
@@ -8,21 +8,31 @@
 static test_err_t test_check_action_mode(void);
 static test_err_t test_check_comm_mode(void);
 static test_err_t test_check_list_type(void);
+static test_err_t test_check_can_bit_timing(void);
 static test_err_t test_default_letter(void);
 
 int main(void) {
-  if (test_check_action_mode() != TEST_PASS) {
-    return TEST_FAIL;
+  test_err_t ret = test_check_action_mode();
+  if (ret != TEST_PASS) {
+    return ret;
   }
-  if (test_check_comm_mode() != TEST_PASS) {
-    return TEST_FAIL;
+  ret = test_check_comm_mode();
+  if (ret != TEST_PASS) {
+    return ret;
   }
-  if (test_check_list_type() != TEST_PASS) {
-    return TEST_FAIL;
+  ret = test_check_list_type();
+  if (ret != TEST_PASS) {
+    return ret;
   }
-  if (test_default_letter() != TEST_PASS) {
-    return TEST_FAIL;
+  ret = test_check_can_bit_timing();
+  if (ret != TEST_PASS) {
+    return ret;
   }
+  ret = test_default_letter();
+  if (ret != TEST_PASS) {
+    return ret;
+  }
+
   return TEST_PASS;
 }
 
@@ -113,6 +123,44 @@ static test_err_t test_check_list_type(void) {
     printf("check_list_type: invalid type returns OK.\n");
     return TEST_FAIL;
   }
+  return TEST_PASS;
+}
+
+static test_err_t test_check_can_bit_timing(void) {
+  ck_can_bit_timing_t bit_timing = ck_default_bit_timing();
+  if (ck_check_can_bit_timing(&bit_timing) != CK_OK) {
+    printf("check_can_bit_timing: valid bit timing returns error.\n");
+    return TEST_FAIL;
+  }
+
+  // Illegal parameters test
+  ck_can_bit_timing_t illegal_prescaler = bit_timing;
+  ck_can_bit_timing_t illegal_tq = bit_timing;
+  ck_can_bit_timing_t illegal_ps2 = bit_timing;
+  ck_can_bit_timing_t illegal_sjw = bit_timing;
+
+  illegal_prescaler.prescaler = 0;
+  illegal_tq.time_quanta = 0;
+  illegal_ps2.phase_seg2 = 0;
+  illegal_sjw.sjw = 0;
+
+  if (ck_check_can_bit_timing(&illegal_prescaler) == CK_OK) {
+    printf("check_can_bit_timing: illegal prescaler returned OK.\n");
+    return TEST_FAIL;
+  }
+  if (ck_check_can_bit_timing(&illegal_tq) == CK_OK) {
+    printf("check_can_bit_timing: illegal time quanta returned OK.\n");
+    return TEST_FAIL;
+  }
+  if (ck_check_can_bit_timing(&illegal_ps2) == CK_OK) {
+    printf("check_can_bit_timing: illegal phase seg 2 returned OK.\n");
+    return TEST_FAIL;
+  }
+  if (ck_check_can_bit_timing(&illegal_sjw) == CK_OK) {
+    printf("check_can_bit_timing: illegal sjw returned OK.\n");
+    return TEST_FAIL;
+  }
+
   return TEST_PASS;
 }
 

--- a/libs/can-kingdom/tests/types-test.c
+++ b/libs/can-kingdom/tests/types-test.c
@@ -117,7 +117,7 @@ static test_err_t test_check_list_type(void) {
 }
 
 static test_err_t test_default_letter(void) {
-  ck_letter_t letter = default_letter();
+  ck_letter_t letter = ck_default_letter();
   if (letter.envelope.envelope_no != CK_DEFAULT_LETTER_ENVELOPE) {
     printf("default_letter: incorrect envelope number, expected: %u, got: %u\n",
            CK_DEFAULT_LETTER_ENVELOPE, letter.envelope.envelope_no);

--- a/libs/stm32-common/src/flash.c
+++ b/libs/stm32-common/src/flash.c
@@ -25,11 +25,9 @@ int flash_init(void) {
   }
   flash_erase();
   flash_erased = FLASH_ERASED_SYMBOL;
-  if (flash_write(FLASH_RW_END - sizeof(uint32_t), &flash_erased,
-                  sizeof(flash_erased)) != APP_OK) {
-    return APP_NOT_OK;
-  }
-  return APP_OK;
+
+  return flash_write(FLASH_RW_END - sizeof(uint32_t), &flash_erased,
+                     sizeof(flash_erased));
 }
 
 int flash_erase(void) {

--- a/libs/stm32-postmaster/src/postmaster.c
+++ b/libs/stm32-postmaster/src/postmaster.c
@@ -81,11 +81,155 @@ ck_err_t ck_apply_comm_mode(ck_comm_mode_t mode) {
       if (HAL_CAN_Start(hcan) != HAL_OK) {
         return CK_ERR_SET_MODE_FAILED;
       }
-
       break;
 
     default:
       break;
+  }
+  return CK_OK;
+}
+
+uint8_t ck_get_125kbit_prescaler(void) {
+  return 18;  // NOLINT
+}
+
+ck_err_t ck_set_bit_timing(const ck_can_bit_timing_t *bit_timing) {
+  CAN_HandleTypeDef *hcan = get_can_handle();
+
+  // NOLINTBEGIN(*-magic-numbers)
+  if (bit_timing->prescaler < 1 || bit_timing->prescaler > 32) {
+    return CK_ERR_INVALID_CAN_BIT_TIMING;
+  }
+  hcan->Init.Prescaler = bit_timing->prescaler;
+
+  uint8_t tseg1 = bit_timing->time_quanta - 1 - bit_timing->phase_seg2;
+
+  switch (tseg1) {
+    case 1:
+      hcan->Init.TimeSeg1 = CAN_BS1_1TQ;
+      break;
+    case 2:
+      hcan->Init.TimeSeg1 = CAN_BS1_2TQ;
+      break;
+    case 3:
+      hcan->Init.TimeSeg1 = CAN_BS1_3TQ;
+      break;
+    case 4:
+      hcan->Init.TimeSeg1 = CAN_BS1_4TQ;
+      break;
+    case 5:
+      hcan->Init.TimeSeg1 = CAN_BS1_5TQ;
+      break;
+    case 6:
+      hcan->Init.TimeSeg1 = CAN_BS1_6TQ;
+      break;
+    case 7:
+      hcan->Init.TimeSeg1 = CAN_BS1_7TQ;
+      break;
+    case 8:
+      hcan->Init.TimeSeg1 = CAN_BS1_8TQ;
+      break;
+    case 9:
+      hcan->Init.TimeSeg1 = CAN_BS1_9TQ;
+      break;
+    case 10:
+      hcan->Init.TimeSeg1 = CAN_BS1_10TQ;
+      break;
+    case 11:
+      hcan->Init.TimeSeg1 = CAN_BS1_11TQ;
+      break;
+    case 12:
+      hcan->Init.TimeSeg1 = CAN_BS1_12TQ;
+      break;
+    case 13:
+      hcan->Init.TimeSeg1 = CAN_BS1_13TQ;
+      break;
+    case 14:
+      hcan->Init.TimeSeg1 = CAN_BS1_14TQ;
+      break;
+    case 15:
+      hcan->Init.TimeSeg1 = CAN_BS1_15TQ;
+      break;
+    case 16:
+      hcan->Init.TimeSeg1 = CAN_BS1_16TQ;
+      break;
+    default:
+      return CK_ERR_INVALID_CAN_BIT_TIMING;
+  }
+
+  switch (bit_timing->phase_seg2) {
+    case 1:
+      hcan->Init.TimeSeg2 = CAN_BS2_1TQ;
+      break;
+    case 2:
+      hcan->Init.TimeSeg2 = CAN_BS2_2TQ;
+      break;
+    case 3:
+      hcan->Init.TimeSeg2 = CAN_BS2_3TQ;
+      break;
+    case 4:
+      hcan->Init.TimeSeg2 = CAN_BS2_4TQ;
+      break;
+    case 5:
+      hcan->Init.TimeSeg2 = CAN_BS2_5TQ;
+      break;
+    case 6:
+      hcan->Init.TimeSeg2 = CAN_BS2_6TQ;
+      break;
+    case 7:
+      hcan->Init.TimeSeg2 = CAN_BS2_7TQ;
+      break;
+    case 8:
+      hcan->Init.TimeSeg2 = CAN_BS2_8TQ;
+      break;
+    default:
+      return CK_ERR_INVALID_CAN_BIT_TIMING;
+  }
+
+  switch (bit_timing->sjw) {
+    case 1:
+      hcan->Init.SyncJumpWidth = CAN_SJW_1TQ;
+      break;
+    case 2:
+      hcan->Init.SyncJumpWidth = CAN_SJW_2TQ;
+      break;
+    case 3:
+      hcan->Init.SyncJumpWidth = CAN_SJW_3TQ;
+      break;
+    case 4:
+      hcan->Init.SyncJumpWidth = CAN_SJW_4TQ;
+      break;
+    default:
+      return CK_ERR_INVALID_CAN_BIT_TIMING;
+  }
+  // NOLINTEND(*-magic-numbers)
+
+  // Go off bus
+  if (HAL_CAN_GetState(hcan) == HAL_CAN_STATE_LISTENING) {
+    if (HAL_CAN_Stop(hcan) != HAL_OK) {
+      return CK_ERR_PERIPHERAL;
+    }
+  }
+
+  if (HAL_CAN_Init(hcan) != HAL_OK) {
+    return CK_ERR_INVALID_CAN_BIT_TIMING;
+  }
+
+  return CK_OK;
+}
+
+ck_err_t ck_save_bit_timing(const ck_can_bit_timing_t *bit_timing) {
+  if (flash_write(FLASH_RW_START, bit_timing, sizeof(ck_can_bit_timing_t)) !=
+      APP_OK) {
+    return CK_ERR_PERIPHERAL;
+  }
+  return CK_OK;
+}
+
+ck_err_t ck_load_bit_timing(ck_can_bit_timing_t *bit_timing) {
+  if (flash_read(FLASH_RW_START, bit_timing, sizeof(ck_can_bit_timing_t)) !=
+      APP_OK) {
+    return CK_ERR_PERIPHERAL;
   }
   return CK_OK;
 }

--- a/libs/stm32-postmaster/src/postmaster.c
+++ b/libs/stm32-postmaster/src/postmaster.c
@@ -1,8 +1,8 @@
 #include "postmaster.h"
 
+#include "error.h"
+#include "flash.h"
 #include "postmaster-hal.h"
-
-static ck_comm_mode_t comm_mode;
 
 ck_err_t ck_send_letter(const ck_letter_t *letter, uint8_t dlc) {
   CAN_HandleTypeDef *hcan = get_can_handle();
@@ -40,7 +40,7 @@ ck_err_t ck_send_letter(const ck_letter_t *letter, uint8_t dlc) {
   return CK_OK;
 }
 
-ck_err_t ck_set_comm_mode(ck_comm_mode_t mode) {
+ck_err_t ck_apply_comm_mode(ck_comm_mode_t mode) {
   ck_err_t ret = ck_check_comm_mode(mode);
   if (ret != CK_OK) {
     return ret;
@@ -50,8 +50,6 @@ ck_err_t ck_set_comm_mode(ck_comm_mode_t mode) {
   switch (mode) {
     case CK_COMM_MODE_COMMUNICATE:
     case CK_COMM_MODE_LISTEN_ONLY:
-      comm_mode = mode;
-
       if (HAL_CAN_GetState(hcan) == HAL_CAN_STATE_LISTENING) {
         if (HAL_CAN_Stop(hcan) != HAL_OK) {
           return CK_ERR_SET_MODE_FAILED;
@@ -66,12 +64,9 @@ ck_err_t ck_set_comm_mode(ck_comm_mode_t mode) {
       if (HAL_CAN_Start(hcan) != HAL_OK) {
         return CK_ERR_SET_MODE_FAILED;
       }
-
       break;
 
     case CK_COMM_MODE_SILENT:
-      comm_mode = mode;
-
       if (HAL_CAN_GetState(hcan) == HAL_CAN_STATE_LISTENING) {
         if (HAL_CAN_Stop(hcan) != HAL_OK) {
           return CK_ERR_SET_MODE_FAILED;
@@ -94,5 +89,3 @@ ck_err_t ck_set_comm_mode(ck_comm_mode_t mode) {
   }
   return CK_OK;
 }
-
-ck_comm_mode_t ck_get_comm_mode(void) { return comm_mode; }

--- a/scripts/ck-startup.py
+++ b/scripts/ck-startup.py
@@ -6,9 +6,9 @@ with canlib.openChannel(channel=0, flags=canlib.Open.REQUIRE_INIT_ACCESS, bitrat
     default_letter = Frame(id_=2031, data=[0xAA,0xAA,0xAA,0xAA,0xAA,0xAA,0xAA,0xAA])
     kp0 = Frame(id_=0, dlc=8, data=[0,0,0,0x3,0,0,0,0]) # Set communication mode to COMMUNICATE
     kp1 = Frame(id_=0, dlc=8, data=[0,1,0,0,0,2,0,0]) # Give base number and ask for response page 0
-    kp2_0 = Frame(id_=0, dlc=8, data=[0,2,2,0,0,0,2,0x3]) # Assign envelope 2 to folder 2
-    kp2_1 = Frame(id_=0, dlc=8, data=[0,2,3,0,0,0,3,0x3]) # Assign envelope 3 to folder 3
-    kp2_2 = Frame(id_=0, dlc=8, data=[0,2,4,0,0,0,4,0x3]) # Assign envelope 4 to folder 4
+    kp2_0 = Frame(id_=0, dlc=8, data=[0,2,0,1,0,0,2,0x3]) # Assign envelope 0x100 to folder 2
+    kp2_1 = Frame(id_=0, dlc=8, data=[0,2,1,1,0,0,3,0x3]) # Assign envelope 0x101 to folder 3
+    kp2_2 = Frame(id_=0, dlc=8, data=[0,2,2,1,0,0,4,0x3]) # Assign envelope 0x102 to folder 4
 
     ch.writeWait(default_letter, -1)
     ch.writeWait(kp1, -1)

--- a/scripts/ck-test-kp8.py
+++ b/scripts/ck-test-kp8.py
@@ -1,3 +1,4 @@
+from time import sleep
 from canlib import canlib, Frame
 
 default_letter = Frame(id_=2031, data=[0xAA,0xAA,0xAA,0xAA,0xAA,0xAA,0xAA,0xAA])
@@ -6,6 +7,8 @@ assign_folder2 = Frame(id_=0, dlc=8, data=[0,2,0,1,0,0,2,0x3]) # Assign envelope
 assign_folder3 = Frame(id_=0, dlc=8, data=[0,2,1,1,0,0,3,0x3]) # Assign envelope 0x101 to folder 3
 assign_folder4 = Frame(id_=0, dlc=8, data=[0,2,2,1,0,0,4,0x3]) # Assign envelope 0x102 to folder 4
 communicate = Frame(id_=0, dlc=8, data=[0,0,0,0x3,0,0,0,0]) # Set communication mode to COMMUNICATE
+change_bitrate = Frame(id_=0, dlc=8, data=[0,8,0,0,9,8,1,1]) # Set bitrate to 500kbit/s
+reset = Frame(id_=0, dlc=8, data=[0,0,0,0x55,0,0,0,0]) # Reset communication and set communication mode to SILENT
 
 with canlib.openChannel(channel=0, flags=canlib.Open.REQUIRE_INIT_ACCESS, bitrate=canlib.Bitrate.BITRATE_125K) as ch:
     ch.setBusOutputControl(canlib.Driver.NORMAL)
@@ -17,4 +20,18 @@ with canlib.openChannel(channel=0, flags=canlib.Open.REQUIRE_INIT_ACCESS, bitrat
     ch.writeWait(assign_folder3, -1)
     ch.writeWait(assign_folder4, -1)
     ch.writeWait(communicate, -1)
+    sleep(0.5) # give time for communication
+    ch.writeWait(change_bitrate, -1)
+    ch.writeWait(reset, -1)
+
     ch.busOff()
+
+with canlib.openChannel(channel=0, flags=canlib.Open.REQUIRE_INIT_ACCESS, bitrate=canlib.Bitrate.BITRATE_500K) as ch:
+    ch.setBusOutputControl(canlib.Driver.NORMAL)
+    ch.busOn()
+
+    ch.writeWait(default_letter, 1000)
+    ch.writeWait(default_letter, 1000)
+    ch.writeWait(communicate, -1)
+    frame = ch.read(timeout=100);
+


### PR DESCRIPTION
- chore(can-kingdom): rename default_letter() to ck_default_letter()
- fix(can-kingdom): test a multibyte envelope
- fix(scripts): use same ID as DBC for battery in ck-startup
- fix(can-kingdom): add null pointer checks to king.c
- chore(can-kingdom): update KP0 to match CK v4
- chore(can-kingdom): move startup sequence from battery to CK
- chore(can-kingdom): add CAN bit timing helpers
- feat(can-kingdom): add king's page 8 for setting bit timing
- feat(scripts): add KP8 integration test
- fix(can-kingdom): assign envelope only if it's not already assigned
- fix(stm32-common): small refactor in flash.c
- fix(can-kingdom): explicit envelope member assignment
