### PR TITLE
fix: rework flash RW functionality

### DIFF
--- a/apps/battery-node/src/main.c
+++ b/apps/battery-node/src/main.c
@@ -101,11 +101,6 @@ int main(void) {
   i2c1_init();
   can_init();
 
-  if (flash_init() != APP_OK) {
-    print(&peripherals->huart1, "Error initiliazing flash.\r\n");
-    error();
-  }
-
   task_init();
   ck_init();
 

--- a/apps/io-node/src/main.c
+++ b/apps/io-node/src/main.c
@@ -34,10 +34,6 @@ int main(void) {
   // Reset of all peripherals, Initializes the Flash interface and the Systick.
   HAL_Init();
 
-  if (flash_init() != APP_OK) {
-    error();
-  }
-
   // Configure the system clock
   system_clock_init();
 

--- a/apps/radio-node/src/main.c
+++ b/apps/radio-node/src/main.c
@@ -56,10 +56,6 @@ int main(void) {
   // Reset of all peripherals, Initializes the Flash interface and the Systick.
   HAL_Init();
 
-  if (flash_init() != APP_OK) {
-    error();
-  }
-
   // Configure the system clock
   system_clock_init();
 

--- a/apps/servo-node/src/main.c
+++ b/apps/servo-node/src/main.c
@@ -51,10 +51,6 @@ int main(void) {
   // Reset of all peripherals, Initializes the Flash interface and the Systick.
   HAL_Init();
 
-  if (flash_init() != APP_OK) {
-    error();
-  }
-
   // Configure the system clock
   system_clock_init();
 

--- a/libs/stm32-common/include/flash.h
+++ b/libs/stm32-common/include/flash.h
@@ -11,10 +11,6 @@ extern "C" {
 #define FLASH_RW_START 0x0807F800
 #define FLASH_RW_END (FLASH_RW_START + 2 * 1024)
 
-// Setup the writeable flash memory area. Return APP_OK on success, APP_NOT_OK
-// otherwise.
-int flash_init(void);
-
 // Erase the persistent storage. This needs to be done prior to first time
 // programming of the flash. Return APP_OK on success, APP_NOT_OK otherwise.
 int flash_erase(void);
@@ -23,8 +19,8 @@ int flash_erase(void);
 int flash_read(uint32_t addr, void *data, size_t len);
 
 // Write to FLASH_RW area. The len parameter needs to be word-aligned (32-bit)
-// since we program in word mode. Return APP_OK on success, APP_NOT_OK
-// otherwise.
+// since we program in word mode. The page that is written to will be fully
+// erased before write. Return APP_OK on success, APP_NOT_OK otherwise.
 int flash_write(uint32_t addr, const void *data, size_t len);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Flash always needs to be erased before writing, so remove flash_init()
and always erase before write.
