### PR TITLE
fix(apps): switch to non-blocking prints

### DIFF
--- a/apps/battery-node/src/interrupts.c
+++ b/apps/battery-node/src/interrupts.c
@@ -21,3 +21,8 @@ void USB_LP_CAN_RX0_IRQHandler(void) {
 
 // EXTI line[15:10] interrupt handler.
 void EXTI15_10_IRQHandler(void) { HAL_GPIO_EXTI_IRQHandler(OVER_CURRENT_Pin); }
+
+void USART1_IRQHandler(void) {
+  peripherals_t *peripherals = get_peripherals();
+  HAL_UART_IRQHandler(&peripherals->huart1);
+}

--- a/apps/battery-node/src/peripherals.c
+++ b/apps/battery-node/src/peripherals.c
@@ -8,6 +8,7 @@
 #define DMA2_Channel1_IRQ_PRIORITY 5
 #define EXTI15_10_IRQ_PRIORITY 5
 #define USB_LP_CAN_RX0_IRQ_PRIORITY 5
+#define USART1_IRQ_PRIORITY 5
 #define PENDSV_IRQ_PRIORITY 15
 
 static peripherals_t peripherals;
@@ -702,6 +703,10 @@ void HAL_UART_MspInit(UART_HandleTypeDef* huart) {
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
     GPIO_InitStruct.Alternate = GPIO_AF7_USART1;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+    /* USART1 interrupt Init */
+    HAL_NVIC_SetPriority(USART1_IRQn, USART1_IRQ_PRIORITY, 0);
+    HAL_NVIC_EnableIRQ(USART1_IRQn);
   }
 }
 
@@ -721,5 +726,8 @@ void HAL_UART_MspDeInit(UART_HandleTypeDef* huart) {
     PA10     ------> USART1_RX
     */
     HAL_GPIO_DeInit(GPIOA, GPIO_PIN_9 | GPIO_PIN_10);
+
+    /* USART1 interrupt DeInit */
+    HAL_NVIC_DisableIRQ(USART1_IRQn);
   }
 }

--- a/apps/io-node/src/interrupts.c
+++ b/apps/io-node/src/interrupts.c
@@ -7,3 +7,8 @@ void DMA1_Channel1_IRQHandler(void) {
   peripherals_t *peripherals = get_peripherals();
   HAL_DMA_IRQHandler(&peripherals->hdma_adc1);
 }
+
+void USART1_IRQHandler(void) {
+  peripherals_t *peripherals = get_peripherals();
+  HAL_UART_IRQHandler(&peripherals->huart1);
+}

--- a/apps/io-node/src/peripherals.c
+++ b/apps/io-node/src/peripherals.c
@@ -5,6 +5,7 @@
 #include "stm32f3xx_hal.h"
 
 #define DMA1_Channel1_IRQ_PRIORITY 5
+#define USART1_IRQ_PRIORITY 5
 #define PENDSV_IRQ_PRIORITY 15
 
 static peripherals_t peripherals;
@@ -554,6 +555,10 @@ void HAL_UART_MspInit(UART_HandleTypeDef* huart) {
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
     GPIO_InitStruct.Alternate = GPIO_AF7_USART1;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+    /* USART1 interrupt Init */
+    HAL_NVIC_SetPriority(USART1_IRQn, USART1_IRQ_PRIORITY, 0);
+    HAL_NVIC_EnableIRQ(USART1_IRQn);
   }
 }
 
@@ -573,5 +578,8 @@ void HAL_UART_MspDeInit(UART_HandleTypeDef* huart) {
     PA10     ------> USART1_RX
     */
     HAL_GPIO_DeInit(GPIOA, GPIO_PIN_9 | GPIO_PIN_10);
+
+    /* USART1 interrupt DeInit */
+    HAL_NVIC_DisableIRQ(USART1_IRQn);
   }
 }

--- a/apps/radio-node/src/interrupts.c
+++ b/apps/radio-node/src/interrupts.c
@@ -9,7 +9,6 @@ void USB_HP_CAN_TX_IRQHandler(void) {
   HAL_CAN_IRQHandler(&peripherals->hcan);
 }
 
-// UART1 interrupt handler.
 void USART1_IRQHandler(void) {
   peripherals_t *peripherals = get_peripherals();
   HAL_UART_IRQHandler(&peripherals->huart1);

--- a/apps/servo-node/src/interrupts.c
+++ b/apps/servo-node/src/interrupts.c
@@ -17,3 +17,8 @@ void USB_HP_CAN_TX_IRQHandler(void) {
   peripherals_t *peripherals = get_peripherals();
   HAL_CAN_IRQHandler(&peripherals->hcan);
 }
+
+void USART1_IRQHandler(void) {
+  peripherals_t *peripherals = get_peripherals();
+  HAL_UART_IRQHandler(&peripherals->huart1);
+}

--- a/apps/servo-node/src/peripherals.c
+++ b/apps/servo-node/src/peripherals.c
@@ -5,6 +5,7 @@
 
 #define DMA1_Channel1_IRQ_PRIORITY 5
 #define DMA2_Channel1_IRQ_PRIORITY 5
+#define USART1_IRQ_PRIORITY 5
 #define USB_HP_CAN_TX_IRQ_PRIORITY 5
 #define PENDSV_IRQ_PRIORITY 15
 
@@ -836,6 +837,10 @@ void HAL_UART_MspInit(UART_HandleTypeDef* huart) {
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
     GPIO_InitStruct.Alternate = GPIO_AF7_USART1;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+    /* USART1 interrupt Init */
+    HAL_NVIC_SetPriority(USART1_IRQn, USART1_IRQ_PRIORITY, 0);
+    HAL_NVIC_EnableIRQ(USART1_IRQn);
   }
 }
 
@@ -855,5 +860,8 @@ void HAL_UART_MspDeInit(UART_HandleTypeDef* huart) {
     PA10     ------> USART1_RX
     */
     HAL_GPIO_DeInit(GPIOA, GPIO_PIN_9 | GPIO_PIN_10);
+
+    /* USART1 interrupt DeInit */
+    HAL_NVIC_DisableIRQ(USART1_IRQn);
   }
 }

--- a/cubemx/battery-node.ioc
+++ b/cubemx/battery-node.ioc
@@ -169,6 +169,7 @@ NVIC.SavedPendsvIrqHandlerGenerated=true
 NVIC.SavedSvcallIrqHandlerGenerated=true
 NVIC.SavedSystickIrqHandlerGenerated=true
 NVIC.SysTick_IRQn=true\:15\:0\:false\:false\:true\:true\:false\:true\:false
+NVIC.USART1_IRQn=true\:5\:0\:false\:false\:true\:true\:true\:true\:true
 NVIC.USB_LP_CAN_RX0_IRQn=true\:5\:0\:false\:false\:true\:true\:true\:true\:true
 NVIC.UsageFault_IRQn=true\:0\:0\:false\:false\:true\:false\:false\:false\:false
 PA0.GPIOParameters=GPIO_Label

--- a/cubemx/io-node.ioc
+++ b/cubemx/io-node.ioc
@@ -142,6 +142,7 @@ NVIC.SavedPendsvIrqHandlerGenerated=true
 NVIC.SavedSvcallIrqHandlerGenerated=true
 NVIC.SavedSystickIrqHandlerGenerated=true
 NVIC.SysTick_IRQn=true\:15\:0\:false\:false\:true\:true\:false\:true\:false
+NVIC.USART1_IRQn=true\:5\:0\:false\:false\:true\:true\:true\:true\:true
 NVIC.UsageFault_IRQn=true\:0\:0\:false\:false\:true\:false\:false\:false\:false
 PA0.GPIOParameters=GPIO_Label
 PA0.GPIO_Label=AN1

--- a/cubemx/servo-node.ioc
+++ b/cubemx/servo-node.ioc
@@ -161,6 +161,7 @@ NVIC.SavedPendsvIrqHandlerGenerated=true
 NVIC.SavedSvcallIrqHandlerGenerated=true
 NVIC.SavedSystickIrqHandlerGenerated=true
 NVIC.SysTick_IRQn=true\:15\:0\:false\:false\:true\:true\:false\:true\:false
+NVIC.USART1_IRQn=true\:5\:0\:false\:false\:true\:true\:true\:true\:true
 NVIC.USB_HP_CAN_TX_IRQn=true\:5\:0\:false\:false\:true\:true\:true\:true\:true
 NVIC.UsageFault_IRQn=true\:0\:0\:false\:false\:true\:false\:false\:false\:false
 PA0.GPIOParameters=GPIO_Label

--- a/libs/stm32-common/src/print.c
+++ b/libs/stm32-common/src/print.c
@@ -3,5 +3,5 @@
 #include <string.h>
 
 void print(UART_HandleTypeDef *huart, char *str) {
-  HAL_UART_Transmit(huart, (uint8_t *)str, strlen(str), HAL_MAX_DELAY);
+  HAL_UART_Transmit_IT(huart, (uint8_t *)str, strlen(str));
 }


### PR DESCRIPTION
Use interrupt-based prints to avoid blocking tasks and affecting app
behavior too much by printing.
