### PR TITLE
fix(apps): init DMA before ADC peripherals

### DIFF
--- a/apps/battery-node/src/peripherals.c
+++ b/apps/battery-node/src/peripherals.c
@@ -25,11 +25,11 @@ void peripherals_init(void) {
   common_peripherals_init();
   peripherals.common_peripherals = get_common_peripherals();
 
+  gpio_init();
+  dma_init();  // Must be called before ADC init functions.
   adc1_init();
   adc2_init();
   i2c1_init();
-  dma_init();
-  gpio_init();
 }
 
 /**

--- a/apps/io-node/src/peripherals.c
+++ b/apps/io-node/src/peripherals.c
@@ -22,11 +22,11 @@ void peripherals_init(void) {
   common_peripherals_init();
   peripherals.common_peripherals = get_common_peripherals();
 
+  gpio_init();
+  dma_init();  // Must be called before ADC init functions.
   adc1_init();
   i2c1_init();
   spi3_init();
-  dma_init();
-  gpio_init();
 }
 
 void adc1_init(void) {

--- a/apps/servo-node/src/peripherals.c
+++ b/apps/servo-node/src/peripherals.c
@@ -29,7 +29,7 @@ void peripherals_init(void) {
   peripherals.common_peripherals = get_common_peripherals();
 
   gpio_init();
-  dma_init();
+  dma_init();  // Must be called before ADC init functions.
   adc1_init();
   adc2_init();
   i2c1_init();


### PR DESCRIPTION
DMA must be configured before ADC since ADC is configured in DMA mode.
