### PR TITLE
feat(battery): monitor total current draw in SW

### DIFF
--- a/apps/battery-monitor/include/app.h
+++ b/apps/battery-monitor/include/app.h
@@ -42,6 +42,12 @@ typedef enum {
 
 void set_jumper_config(jumper_config_t jumper_config);
 
+// Values in mA.
+typedef enum {
+  FUSE_50_AMPERE = 50000,
+  FUSE_100_AMPERE = 100000,
+} fuse_config_t;
+
 typedef enum {
   NONE = 0,
   RED,


### PR DESCRIPTION
On the power board, the HW over-current protection works only when we
have two 50A fuses connected, since it reacts when current exceeds
100A. Since it's possible to have only one 50A fuse, we implement
over-current protection in SW as well, to avoid unnecessary burning of
fuses. The SW over-current protection is active for the 100A fuse
configuration as well.
