### PR TITLE
fix(servo): correct angle to PWM pulse conversion

### DIFF
--- a/apps/servo/src/ck-rx-letters.c
+++ b/apps/servo/src/ck-rx-letters.c
@@ -71,13 +71,13 @@ int process_steering_letter(const ck_letter_t *letter) {
       if (angle < -90 || angle > 90) {  // NOLINT
         return APP_NOT_OK;
       }
-      /* -90 deg => 1000 µs pulse
-       *  90 deg => 2000 µs pulse
+      /* -90 deg => 500 µs pulse
+       *  90 deg => 2500 µs pulse
        *  0  deg => 1500 µs pulse
        *
-       *  y = kx + m => m = 1500, k = 500/90
+       *  y = kx + m => m = 1500, k = 1000/90
        */
-      const float pulse_float = (float)angle * (500 / 90.0F) + 1500;
+      const float pulse_float = (float)angle * (1000 / 90.0F) + 1500;
 
       pulse = (uint32_t)(pulse_float + 0.5);  // NOLINT
       break;

--- a/integration/ck-test-servo-conf.py
+++ b/integration/ck-test-servo-conf.py
@@ -27,9 +27,9 @@ with canlib.openChannel(
     ch.writeWait(servo.set_potentiometer_35, -1)
     ch.writeWait(servo.set_pwm_conf_333hz, -1)
 
-    ch.writeWait(servo.steer_pulse_2000, -1)
+    ch.writeWait(servo.steer_pulse_2500, -1)
     sleep(2)
-    ch.writeWait(servo.steer_pulse_1000, -1)
+    ch.writeWait(servo.steer_pulse_500, -1)
     sleep(2)
     ch.writeWait(servo.steer_angle_90, -1)
     sleep(2)

--- a/integration/servo.py
+++ b/integration/servo.py
@@ -35,11 +35,11 @@ set_potentiometer_35 = Frame(id_=0x205, dlc=2, data=[0x23, 0])
 # Set PWM frequency to 333 Hz
 set_pwm_conf_333hz = Frame(id_=0x206, dlc=2, data=[0x4D, 0x1])
 
-# Set steering PWM pulse to 1000 µs
-steer_pulse_1000 = Frame(id_=0x207, dlc=3, data=[0, 0xE8, 0x3])
+# Set steering PWM pulse to 500 µs
+steer_pulse_500 = Frame(id_=0x207, dlc=3, data=[0, 0xF4, 0x1])
 
-# Set steering PWM pulse to 2000 µs
-steer_pulse_2000 = Frame(id_=0x207, dlc=3, data=[0, 0xD0, 0x7])
+# Set steering PWM pulse to 2500 µs
+steer_pulse_2500 = Frame(id_=0x207, dlc=3, data=[0, 0xC4, 0x9])
 
 # Set steering angle to 90 degrees
 steer_angle_90 = Frame(id_=0x207, dlc=3, data=[1, 0x5A, 0])


### PR DESCRIPTION
The pulse width of 1000-2000 microseconds applies for a 90 degree
end-to-end servo. To support 180 degree end-to-end servos, we need a
pulse between 500-2500 microseconds.
