### PR TITLE
feat(battery): enable setting voltage output over CAN

### DIFF
--- a/integration/battery.py
+++ b/integration/battery.py
@@ -57,6 +57,9 @@ set_0ma_current = Frame(id_=0x103, dlc=7, data=[0xFF, 0xFF, 0x01, 0, 0, 0, 0])
 # Set over-current threshold to 49500mA. All other values are ignored.
 set_49500ma_current = Frame(id_=0x103, dlc=7, data=[0xFF, 0xFF, 0x01, 0x5C, 0xC1, 0, 0])
 
+# Set regulated output voltage to 5V.
+set_reg_out_voltage_5v = Frame(id_=0x104, dlc=2, data=[0x88, 0x13])
+
 set_reg_pwr_off = Frame(id_=0x105, dlc=2, data=[0, 1])  # Set regulated power out OFF
 
 set_reg_pwr_on = Frame(id_=0x105, dlc=2, data=[1, 1])  # Set regulated power out ON

--- a/integration/ck-test-battery-conf.py
+++ b/integration/ck-test-battery-conf.py
@@ -25,6 +25,8 @@ with canlib.openChannel(
 
     ch.writeWait(ck.communicate, -1)
 
+    ch.writeWait(battery.set_reg_out_voltage_5v, -1)
+
     sleep(2)
     ch.writeWait(battery.set_reg_pwr_off, -1)
     sleep(2)

--- a/integration/ck-test-servo-conf.py
+++ b/integration/ck-test-servo-conf.py
@@ -27,7 +27,7 @@ with canlib.openChannel(
 
     ch.writeWait(ck.communicate, -1)
 
-    ch.writeWait(servo.set_potentiometer_35, -1)
+    ch.writeWait(servo.set_servo_voltage_7400mv, -1)
     ch.writeWait(servo.set_pwm_conf_333hz, -1)
 
     ch.writeWait(servo.set_steer_trim_pulse_200, -1)

--- a/integration/servo.py
+++ b/integration/servo.py
@@ -49,8 +49,8 @@ assign_steering_trim_rx = Frame(
 # CAN report frequency receive
 assign_report_freq_rx = Frame(id_=0, dlc=8, data=[ck.servo_id, 2, 9, 2, 0, 0, 11, 0x3])
 
-# Set potentiometer value to 35
-set_potentiometer_35 = Frame(id_=0x205, dlc=2, data=[0x23, 0])
+# Set servo votlage to 7400 mV
+set_servo_voltage_7400mv = Frame(id_=0x205, dlc=2, data=[0xE8, 0x1C])
 
 # Set PWM frequency to 333 Hz
 set_pwm_conf_333hz = Frame(id_=0x206, dlc=2, data=[0x4D, 0x1])


### PR DESCRIPTION
Regulated voltage output is set using a CAN message that specifies the
desired voltage in mV. It is then converted to a potentiometer value.
