### PR TITLE
feat: allow SBUS receiver to act as rover king

### DIFF
--- a/apps/battery-monitor/src/main.c
+++ b/apps/battery-monitor/src/main.c
@@ -56,7 +56,7 @@ void mayor_init(void) {
 
   default_letter_timer = xTimerCreateStatic(
       "default letter timer", pdMS_TO_TICKS(200),
-      pdFALSE,  // Auto reload timer
+      pdFALSE,  // Don't auto reload timer
       NULL,     // Timer ID, unused
       default_letter_timer_callback, &default_letter_timer_buf);
 

--- a/apps/sbus-receiver/src/main.c
+++ b/apps/sbus-receiver/src/main.c
@@ -58,7 +58,7 @@ void mayor_init(void) {
 
   default_letter_timer = xTimerCreateStatic(
       "default letter timer", pdMS_TO_TICKS(200),
-      pdFALSE,  // Auto reload timer
+      pdFALSE,  // Don't auto reload timer
       NULL,     // Timer ID, unused
       default_letter_timer_callback, &default_letter_timer_buf);
 

--- a/apps/servo/src/main.c
+++ b/apps/servo/src/main.c
@@ -64,7 +64,7 @@ void mayor_init(void) {
 
   default_letter_timer = xTimerCreateStatic(
       "default letter timer", pdMS_TO_TICKS(200),
-      pdFALSE,  // Auto reload timer
+      pdFALSE,  // Don't auto reload timer
       NULL,     // Timer ID, unused
       default_letter_timer_callback, &default_letter_timer_buf);
 

--- a/libs/meson.build
+++ b/libs/meson.build
@@ -7,6 +7,7 @@ subdir('third-party')
 # Convenience source file list
 common_libs_src = [
   can_kingdom_src,
+  rover_src,
   stm32_common_src,
   stm32_postmaster_src,
 
@@ -31,6 +32,7 @@ common_libs_inc = [
 
 common_libs_tidy_files = [
   can_kingdom_tidy_files,
+  rover_tidy_files,
   stm32_common_tidy_files,
   stm32_postmaster_tidy_files,
 ]

--- a/libs/rover/include/rover.h
+++ b/libs/rover/include/rover.h
@@ -5,10 +5,56 @@
 extern "C" {
 #endif
 
+#include <stdint.h>
+
+// City IDs
 #define ROVER_BATTERY_MONITOR_ID 1
 #define ROVER_SERVO_ID 2
 #define ROVER_MOTOR_ID 3
 #define ROVER_SBUS_RECEIVER_ID 4
+
+#define ROVER_BASE_NUMBER 0x400
+
+// Envelope IDs
+// Control messages
+#define ROVER_STEERING_ENVELOPE 0x100
+#define ROVER_THROTTLE_ENVELOPE 0x101
+#define ROVER_STEERING_TRIM_ENVELOPE 0x102
+#define ROVER_THROTTLE_TRIM_ENVELOPE 0x103
+
+// Report messages
+#define ROVER_BATTERY_CELL_VOLTAGES_ENVELOPE 0x200
+#define ROVER_BATTERY_REG_OUT_CURRENT_ENVELOPE 0x201
+#define ROVER_BATTERY_VBAT_OUT_CURRENT_ENVELOPE 0x202
+
+#define ROVER_SERVO_VOLTAGE_ENVELOPE 0x203
+#define ROVER_SERVO_CURRENT_ENVELOPE 0x204
+
+// Settings messages
+#define ROVER_BATTERY_JUMPER_AND_FUSE_CONF_ENVELOPE 0x300
+#define ROVER_BATTERY_REG_OUT_VOLTAGE_ENVELOPE 0x301
+#define ROVER_BATTERY_OUTPUT_ON_OFF_ENVELOPE 0x302
+#define ROVER_BATTERY_REPORT_FREQUENCY_ENVELOPE 0x303
+#define ROVER_BATTERY_LOW_VOLTAGE_CUTOFF_ENVELOPE 0x304
+
+#define ROVER_SERVO_SET_VOLTAGE_ENVELOPE 0x305
+#define ROVER_SERVO_PWM_CONFIG_ENVELOPE 0x306
+#define ROVER_SERVO_REPORT_FREQUENCY_ENVELOPE 0x307
+
+#define ROVER_MOTOR_PWM_CONFIG_ENVELOPE 0x308
+
+typedef struct {
+  uint8_t city;
+  uint16_t envelope;
+  uint8_t folder;
+} rover_assignment_t;
+
+typedef struct {
+  rover_assignment_t *assignments;
+  uint8_t assignment_count;
+} rover_kingdom_t;
+
+rover_kingdom_t *get_rover_kingdom(void);
 
 #ifdef __cplusplus
 }

--- a/libs/rover/meson.build
+++ b/libs/rover/meson.build
@@ -1,1 +1,5 @@
 rover_inc = include_directories('include')
+
+rover_src = files ('src' / 'rover.c')
+
+rover_tidy_files = [rover_src]

--- a/libs/rover/src/rover.c
+++ b/libs/rover/src/rover.c
@@ -1,0 +1,113 @@
+#include "rover.h"
+
+#include <stdbool.h>
+
+#define ASSIGNMENT_COUNT 22
+
+static rover_assignment_t assignments[ASSIGNMENT_COUNT];
+static rover_kingdom_t kingdom = {
+    .assignments = assignments,
+    .assignment_count = ASSIGNMENT_COUNT,
+};
+
+// NOLINTBEGIN(*-magic-numbers)
+void init_assignments(void) {
+  assignments[0].city = ROVER_SERVO_ID;
+  assignments[0].envelope = ROVER_STEERING_ENVELOPE;
+  assignments[0].folder = 9;
+
+  assignments[1].city = ROVER_SERVO_ID;
+  assignments[1].envelope = ROVER_STEERING_TRIM_ENVELOPE;
+  assignments[1].folder = 10;
+
+  assignments[2].city = ROVER_MOTOR_ID;
+  assignments[2].envelope = ROVER_THROTTLE_ENVELOPE;
+  assignments[2].folder = 9;
+
+  assignments[3].city = ROVER_MOTOR_ID;
+  assignments[3].envelope = ROVER_THROTTLE_TRIM_ENVELOPE;
+  assignments[3].folder = 10;
+
+  assignments[4].city = ROVER_SBUS_RECEIVER_ID;
+  assignments[4].envelope = ROVER_STEERING_ENVELOPE;
+  assignments[4].folder = 2;
+
+  assignments[5].city = ROVER_SBUS_RECEIVER_ID;
+  assignments[5].envelope = ROVER_STEERING_TRIM_ENVELOPE;
+  assignments[5].folder = 3;
+
+  assignments[6].city = ROVER_SBUS_RECEIVER_ID;
+  assignments[6].envelope = ROVER_THROTTLE_ENVELOPE;
+  assignments[6].folder = 4;
+
+  assignments[7].city = ROVER_SBUS_RECEIVER_ID;
+  assignments[7].envelope = ROVER_THROTTLE_TRIM_ENVELOPE;
+  assignments[7].folder = 5;
+
+  assignments[8].city = ROVER_BATTERY_MONITOR_ID;
+  assignments[8].envelope = ROVER_BATTERY_CELL_VOLTAGES_ENVELOPE;
+  assignments[8].folder = 2;
+
+  assignments[9].city = ROVER_BATTERY_MONITOR_ID;
+  assignments[9].envelope = ROVER_BATTERY_REG_OUT_CURRENT_ENVELOPE;
+  assignments[9].folder = 3;
+
+  assignments[10].city = ROVER_BATTERY_MONITOR_ID;
+  assignments[10].envelope = ROVER_BATTERY_VBAT_OUT_CURRENT_ENVELOPE;
+  assignments[10].folder = 4;
+
+  assignments[11].city = ROVER_SERVO_ID;
+  assignments[11].envelope = ROVER_SERVO_VOLTAGE_ENVELOPE;
+  assignments[11].folder = 5;
+
+  assignments[12].city = ROVER_SERVO_ID;
+  assignments[12].envelope = ROVER_SERVO_CURRENT_ENVELOPE;
+  assignments[12].folder = 3;
+
+  assignments[13].city = ROVER_BATTERY_MONITOR_ID;
+  assignments[13].envelope = ROVER_BATTERY_JUMPER_AND_FUSE_CONF_ENVELOPE;
+  assignments[13].folder = 5;
+
+  assignments[14].city = ROVER_BATTERY_MONITOR_ID;
+  assignments[14].envelope = ROVER_BATTERY_REG_OUT_VOLTAGE_ENVELOPE;
+  assignments[14].folder = 6;
+
+  assignments[15].city = ROVER_BATTERY_MONITOR_ID;
+  assignments[15].envelope = ROVER_BATTERY_OUTPUT_ON_OFF_ENVELOPE;
+  assignments[15].folder = 7;
+
+  assignments[16].city = ROVER_BATTERY_MONITOR_ID;
+  assignments[16].envelope = ROVER_BATTERY_REPORT_FREQUENCY_ENVELOPE;
+  assignments[16].folder = 8;
+
+  assignments[17].city = ROVER_BATTERY_MONITOR_ID;
+  assignments[17].envelope = ROVER_BATTERY_LOW_VOLTAGE_CUTOFF_ENVELOPE;
+  assignments[17].folder = 9;
+
+  assignments[18].city = ROVER_SERVO_ID;
+  assignments[18].envelope = ROVER_SERVO_SET_VOLTAGE_ENVELOPE;
+  assignments[18].folder = 7;
+
+  assignments[19].city = ROVER_SERVO_ID;
+  assignments[19].envelope = ROVER_SERVO_PWM_CONFIG_ENVELOPE;
+  assignments[19].folder = 8;
+
+  assignments[20].city = ROVER_SERVO_ID;
+  assignments[20].envelope = ROVER_SERVO_REPORT_FREQUENCY_ENVELOPE;
+  assignments[20].folder = 11;
+
+  assignments[21].city = ROVER_MOTOR_ID;
+  assignments[21].envelope = ROVER_MOTOR_PWM_CONFIG_ENVELOPE;
+  assignments[21].folder = 8;
+}
+// NOLINTEND(*-magic-numbers)
+
+rover_kingdom_t *get_rover_kingdom(void) {
+  static bool init_complete = false;
+  if (!init_complete) {
+    init_assignments();
+    init_complete = true;
+  }
+
+  return &kingdom;
+}


### PR DESCRIPTION
If the SBUS receiver doesn't receive a default letter within 150 ms, it
assumes that there is no king in the system. Then, it sends the default
letter, the base number, and assigns envelopes for all other nodes in
the system in order for them to communicate.
