### PR TITLE
feat: add minimal bootloader

### DIFF
--- a/apps/battery-monitor/meson.build
+++ b/apps/battery-monitor/meson.build
@@ -1,4 +1,5 @@
 battery_monitor_inc = include_directories('include')
+
 battery_monitor_src = files(
   'src' / 'adc.c',
   'src' / 'battery.c',
@@ -16,8 +17,8 @@ battery_monitor_elf = executable(
   'battery-monitor.elf',
   [common_libs_src, battery_monitor_src],
   include_directories: [common_libs_inc, battery_monitor_inc],
-  link_depends: stm32_linker_script,
-  link_args: ['-T@0@'.format(stm32_linker_script)],
+  link_depends: stm32_app_linker_script,
+  link_args: ['-T@0@'.format(stm32_app_linker_script)],
 )
 
 battery_monitor_bin = custom_target(

--- a/apps/joystick/meson.build
+++ b/apps/joystick/meson.build
@@ -1,4 +1,5 @@
 joystick_inc = include_directories('include')
+
 joystick_src = files(
   'src' / 'app.c',
   'src' / 'interrupts.c',
@@ -10,8 +11,8 @@ joystick_elf = executable(
   'joystick.elf',
   [common_libs_src, joystick_src],
   include_directories: [common_libs_inc, joystick_inc],
-  link_depends: stm32_linker_script,
-  link_args: ['-T@0@'.format(stm32_linker_script)],
+  link_depends: stm32_app_linker_script,
+  link_args: ['-T@0@'.format(stm32_app_linker_script)],
 )
 
 joystick_bin = custom_target(

--- a/apps/meson.build
+++ b/apps/meson.build
@@ -3,6 +3,28 @@ subdir('joystick')
 subdir('sbus-receiver')
 subdir('servo')
 
+# Build binaries with bootloader. Loops through the app_binaries dictionary and
+# creates binaries with both the bootloader and the app, using cat.
+app_binaries = {
+  'battery-monitor': [battery_monitor_bin],
+  'joystick': [joystick_bin],
+  'motor': [motor_bin], # Built from servo app
+  'sbus-receiver': [sbus_receiver_bin],
+  'servo': [servo_bin],
+}
+
+foreach name, app: app_binaries
+  custom_target(
+    '@0@-with-bootloader.bin'.format(name),
+    build_by_default: true,
+    capture: true, # This makes stdout of cat be captured and written to output file.
+    command: [cat, '@INPUT@'],
+    depends: [stm32_bootloader_bin, app],
+    input: [stm32_bootloader_bin, app],
+    output: ['@0@-with-bootloader.bin'.format(name)],
+  )
+endforeach
+
 apps_tidy_files = [
   battery_monitor_tidy_files,
   joystick_tidy_files,

--- a/apps/sbus-receiver/meson.build
+++ b/apps/sbus-receiver/meson.build
@@ -1,4 +1,5 @@
 sbus_receiver_inc = include_directories('include')
+
 sbus_receiver_src = files(
   'src' / 'ck-data.c',
   'src' / 'freertos-tasks.c',
@@ -13,8 +14,8 @@ sbus_receiver_elf = executable(
   'sbus-receiver.elf',
   [common_libs_src, sbus_receiver_src],
   include_directories: [common_libs_inc, sbus_receiver_inc],
-  link_depends: stm32_linker_script,
-  link_args: ['-T@0@'.format(stm32_linker_script)],
+  link_depends: stm32_app_linker_script,
+  link_args: ['-T@0@'.format(stm32_app_linker_script)],
 )
 
 sbus_receiver_bin = custom_target(

--- a/apps/servo/meson.build
+++ b/apps/servo/meson.build
@@ -1,4 +1,5 @@
 servo_inc = include_directories('include')
+
 servo_src = files(
   'src' / 'adc.c',
   'src' / 'ck-data.c',
@@ -14,8 +15,8 @@ servo_elf = executable(
   'servo.elf',
   [common_libs_src, servo_src],
   include_directories: [common_libs_inc, servo_inc],
-  link_depends: stm32_linker_script,
-  link_args: ['-T@0@'.format(stm32_linker_script)],
+  link_depends: stm32_app_linker_script,
+  link_args: ['-T@0@'.format(stm32_app_linker_script)],
 )
 
 servo_bin = custom_target(
@@ -31,8 +32,8 @@ motor_elf = executable(
   'motor.elf',
   [common_libs_src, servo_src],
   include_directories: [common_libs_inc, servo_inc],
-  link_depends: stm32_linker_script,
-  link_args: ['-T@0@'.format(stm32_linker_script)],
+  link_depends: stm32_app_linker_script,
+  link_args: ['-T@0@'.format(stm32_app_linker_script)],
   c_args: ['-DMOTOR'],
 )
 
@@ -41,7 +42,7 @@ motor_bin = custom_target(
   output: 'motor.bin',
   input: motor_elf,
   command: [objcopy, '-O', 'binary', '-S', '@INPUT@', '@OUTPUT@'],
-  depends: servo_elf,
+  depends: motor_elf,
   build_by_default: true,
 )
 

--- a/libs/meson.build
+++ b/libs/meson.build
@@ -1,8 +1,8 @@
+subdir('third-party')
 subdir('can-kingdom')
 subdir('rover')
 subdir('stm32-common')
 subdir('stm32-postmaster')
-subdir('third-party')
 
 # Convenience source file list
 common_libs_src = [

--- a/libs/stm32-common/meson.build
+++ b/libs/stm32-common/meson.build
@@ -1,6 +1,6 @@
 stm32_common_inc = include_directories('include')
 
-stm32_common_src = files(
+stm32_lib_src =  files(
   'src' / 'assert.c',
   'src' / 'clock.c',
   'src' / 'common-interrupts.c',
@@ -9,23 +9,44 @@ stm32_common_src = files(
   'src' / 'flash.c',
   'src' / 'freertos.c',
   'src' / 'print.c',
+)
+
+stm32_startup_src = files(
   'src' / 'startup_stm32f302xe.s',
   'src' / 'system_stm32f3xx.c',
 )
 
-stm32_linker_script = configure_file(
+stm32_common_src = [stm32_lib_src, stm32_startup_src]
+
+stm32_bootloader_src = files('src' / 'bootloader.c')
+
+stm32_bootloader_linker_script = configure_file(
   copy: true,
-  input: files('src' / 'STM32F302RETx_FLASH.ld'),
+  input: files('src' / 'bootloader.ld'),
   output: '@PLAINNAME@',
 )
 
-stm32_common_tidy_files = files(
-  'src' / 'assert.c',
-  'src' / 'clock.c',
-  'src' / 'common-interrupts.c',
-  'src' / 'common-peripherals.c',
-  'src' / 'error.c',
-  'src' / 'flash.c',
-  'src' / 'freertos.c',
-  'src' / 'print.c',
+stm32_app_linker_script = configure_file(
+  copy: true,
+  input: files('src' / 'app.ld'),
+  output: '@PLAINNAME@',
 )
+
+stm32_bootloader_elf = executable(
+  'stm32-bootloader.elf',
+  [stm32_bootloader_src, stm32_common_src, drivers_src, freertos_src, printf_src],
+  include_directories: [stm32_common_inc, drivers_inc, freertos_inc, printf_inc],
+  link_depends: stm32_bootloader_linker_script,
+  link_args: ['-T@0@'.format(stm32_bootloader_linker_script)],
+)
+
+stm32_bootloader_bin = custom_target(
+  'stm32-bootloader.bin',
+  output: 'stm32-bootloader.bin',
+  input: stm32_bootloader_elf,
+  command: [objcopy, '-O', 'binary', '-S', '--pad-to', '0x08010000', '@INPUT@', '@OUTPUT@'],
+  depends: stm32_bootloader_elf,
+  build_by_default: true,
+)
+
+stm32_common_tidy_files = [stm32_bootloader_src, stm32_lib_src]

--- a/libs/stm32-common/src/app.ld
+++ b/libs/stm32-common/src/app.ld
@@ -1,0 +1,172 @@
+/*
+*****************************************************************************
+** @attention
+**
+** <h2><center>&copy; COPYRIGHT(c) 2019 STMicroelectronics</center></h2>
+**
+** Redistribution and use in source and binary forms, with or without modification,
+** are permitted provided that the following conditions are met:
+**   1. Redistributions of source code must retain the above copyright notice,
+**      this list of conditions and the following disclaimer.
+**   2. Redistributions in binary form must reproduce the above copyright notice,
+**      this list of conditions and the following disclaimer in the documentation
+**      and/or other materials provided with the distribution.
+**   3. Neither the name of STMicroelectronics nor the names of its contributors
+**      may be used to endorse or promote products derived from this software
+**      without specific prior written permission.
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+** AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+** IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+** FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+** DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+** CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+** OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+*****************************************************************************
+*/
+
+/* Specify the memory areas for the boards. */
+MEMORY
+{
+    RAM (rwx)    : ORIGIN = 0x20000000, LENGTH = 64K
+
+    /* 512K flash available. Use 64K for bootloader, 440K for app,
+     * and 8K for storing user data. */
+    BOOTROM (rx) : ORIGIN = 0x08000000, LENGTH = 64K
+    APPROM (rx)  : ORIGIN = 0x08000000 + 64K, LENGTH = 440K
+    STORAGE (rw) : ORIGIN = 0x08000000 + 64K + 440K, LENGTH = 8K
+}
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+/* Highest address of the user mode stack */
+_estack = ORIGIN(RAM) + LENGTH(RAM);    /* end of RAM */
+/* Generate a link error if heap and stack don't fit into RAM */
+_Min_Heap_Size = 0x200;      /* required amount of heap  */
+_Min_Stack_Size = 0x400; /* required amount of stack */
+
+/* Define output sections */
+SECTIONS
+{
+  /* The startup code goes first into APPROM */
+  .isr_vector :
+  {
+    . = ALIGN(4);
+    KEEP(*(.isr_vector)) /* Startup code */
+    . = ALIGN(4);
+  } >APPROM
+
+  /* The program code and other data goes into APPROM */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)           /* .text sections (code) */
+    *(.text*)          /* .text* sections (code) */
+    *(.glue_7)         /* glue arm to thumb code */
+    *(.glue_7t)        /* glue thumb to arm code */
+    *(.eh_frame)
+
+    KEEP (*(.init))
+    KEEP (*(.fini))
+
+    . = ALIGN(4);
+    _etext = .;        /* define a global symbols at end of code */
+  } >APPROM
+
+  /* Constant data goes into APPROM */
+  .rodata :
+  {
+    . = ALIGN(4);
+    *(.rodata)         /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
+    . = ALIGN(4);
+  } >APPROM
+
+  .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >APPROM
+  .ARM : {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } >APPROM
+
+  .preinit_array     :
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } >APPROM
+  .init_array :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } >APPROM
+  .fini_array :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } >APPROM
+
+  /* used by the startup to initialize data */
+  _sidata = LOADADDR(.data);
+
+  /* Initialized data sections goes into RAM, load LMA copy after code */
+  .data :
+  {
+    . = ALIGN(4);
+    _sdata = .;        /* create a global symbol at data start */
+    *(.data)           /* .data sections */
+    *(.data*)          /* .data* sections */
+
+    . = ALIGN(4);
+    _edata = .;        /* define a global symbol at data end */
+  } >RAM AT> APPROM
+
+
+  /* Uninitialized data section */
+  . = ALIGN(4);
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss secion */
+    _sbss = .;         /* define a global symbol at bss start */
+    __bss_start__ = _sbss;
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+
+    . = ALIGN(4);
+    _ebss = .;         /* define a global symbol at bss end */
+    __bss_end__ = _ebss;
+  } >RAM
+
+  /* User_heap_stack section, used to check that there is enough RAM left */
+  ._user_heap_stack :
+  {
+    . = ALIGN(8);
+    PROVIDE ( end = . );
+    PROVIDE ( _end = . );
+    . = . + _Min_Heap_Size;
+    . = . + _Min_Stack_Size;
+    . = ALIGN(8);
+  } >RAM
+
+
+
+  /* Remove information from the standard libraries */
+  /DISCARD/ :
+  {
+    libc.a ( * )
+    libm.a ( * )
+    libgcc.a ( * )
+  }
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+}

--- a/libs/stm32-common/src/bootloader.c
+++ b/libs/stm32-common/src/bootloader.c
@@ -1,0 +1,78 @@
+#include "clock.h"
+#include "common-peripherals.h"
+#include "print.h"
+
+// Bootloader is 64KB.
+#define APPROM_START (FLASH_BASE + 64 * 1024)
+
+// program counter (pc) is in r0, stack pointer (sp) in r1. Loads sp into Main
+// Stack Pointer (MSP) register, and then branches to address given by pc.
+// NOLINTNEXTLINE(readability*,bugprone*)
+__attribute__((naked)) static void start_app(uint32_t pc, uint32_t sp) {
+  __asm(
+      "           \n\
+          msr msp, r1 /* load r1 into MSP */\n\
+          bx r0       /* branch to the address at r0 */\n\
+    ");
+}
+
+int main(void) {
+  HAL_Init();
+  system_clock_init();
+  common_peripherals_init();
+
+  print("Entering bootloader...\r\n");
+
+  uint32_t* app_code = (uint32_t*)APPROM_START;
+  uint32_t app_sp = app_code[0];
+  uint32_t app_start = app_code[1];
+
+  print("Exiting bootloader...\r\n");
+
+  // Resets the peripheral buses, so no need for additional deinit.
+  HAL_DeInit();
+
+  // Relocate vector table
+  SCB->VTOR = APPROM_START;
+  start_app(app_start, app_sp);
+
+  while (1) {
+    // Never reached
+  }
+}
+
+void HAL_CAN_MspInit(CAN_HandleTypeDef* hcan) {
+  if (hcan->Instance == CAN) {
+    can_msp_init();
+  }
+}
+
+void HAL_CAN_MspDeInit(CAN_HandleTypeDef* hcan) {
+  if (hcan->Instance == CAN) {
+    can_msp_deinit();
+  }
+}
+
+void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi) {
+  if (hspi->Instance == SPI1) {
+    spi1_msp_init();
+  }
+}
+
+void HAL_SPI_MspDeInit(SPI_HandleTypeDef* hspi) {
+  if (hspi->Instance == SPI1) {
+    spi1_msp_deinit();
+  }
+}
+
+void HAL_UART_MspInit(UART_HandleTypeDef* huart) {
+  if (huart->Instance == USART1) {
+    uart1_msp_init();
+  }
+}
+
+void HAL_UART_MspDeInit(UART_HandleTypeDef* huart) {
+  if (huart->Instance == USART1) {
+    uart1_msp_deinit();
+  }
+}

--- a/libs/stm32-common/src/bootloader.ld
+++ b/libs/stm32-common/src/bootloader.ld
@@ -1,24 +1,4 @@
 /*
-******************************************************************************
-**
-
-**  File        : LinkerScript.ld
-**
-**  Author		: STM32CubeMX
-**
-**  Abstract    : Linker script for STM32F302RETx series
-**                512Kbytes FLASH and 64Kbytes RAM
-**
-**                Set heap size, stack size and stack location according
-**                to application requirements.
-**
-**                Set memory bank area and size if external memory is used.
-**
-**  Target      : STMicroelectronics STM32
-**
-**  Distribution: The file is distributed “as is,” without any warranty
-**                of any kind.
-**
 *****************************************************************************
 ** @attention
 **
@@ -49,6 +29,18 @@
 *****************************************************************************
 */
 
+/* Specify the memory areas for the boards. */
+MEMORY
+{
+    RAM (rwx)    : ORIGIN = 0x20000000, LENGTH = 64K
+
+    /* 512K flash available. Use 64K for bootloader, 440K for app,
+     * and 8K for storing user data. */
+    BOOTROM (rx) : ORIGIN = 0x08000000, LENGTH = 64K
+    APPROM (rx)  : ORIGIN = 0x08000000 + 64K, LENGTH = 440K
+    STORAGE (rw) : ORIGIN = 0x08000000 + 64K + 440K, LENGTH = 8K
+}
+
 /* Entry Point */
 ENTRY(Reset_Handler)
 
@@ -58,27 +50,18 @@ _estack = ORIGIN(RAM) + LENGTH(RAM);    /* end of RAM */
 _Min_Heap_Size = 0x200;      /* required amount of heap  */
 _Min_Stack_Size = 0x400; /* required amount of stack */
 
-/* Specify the memory areas */
-MEMORY
-{
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 64K
-FLASH (rx)     : ORIGIN = 0x08000000, LENGTH = 510K
-/* Reserve final flash sector for persistent configuration files */
-FLASH_RW (rw)  : ORIGIN = 0x0807F800, LENGTH = 2K
-}
-
 /* Define output sections */
 SECTIONS
 {
-  /* The startup code goes first into FLASH */
+  /* The startup code goes first into BOOTROM */
   .isr_vector :
   {
     . = ALIGN(4);
     KEEP(*(.isr_vector)) /* Startup code */
     . = ALIGN(4);
-  } >FLASH
+  } >BOOTROM
 
-  /* The program code and other data goes into FLASH */
+  /* The program code and other data goes into BOOTROM */
   .text :
   {
     . = ALIGN(4);
@@ -93,44 +76,44 @@ SECTIONS
 
     . = ALIGN(4);
     _etext = .;        /* define a global symbols at end of code */
-  } >FLASH
+  } >BOOTROM
 
-  /* Constant data goes into FLASH */
+  /* Constant data goes into BOOTROM */
   .rodata :
   {
     . = ALIGN(4);
     *(.rodata)         /* .rodata sections (constants, strings, etc.) */
     *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
     . = ALIGN(4);
-  } >FLASH
+  } >BOOTROM
 
-  .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >FLASH
+  .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >BOOTROM
   .ARM : {
     __exidx_start = .;
     *(.ARM.exidx*)
     __exidx_end = .;
-  } >FLASH
+  } >BOOTROM
 
   .preinit_array     :
   {
     PROVIDE_HIDDEN (__preinit_array_start = .);
     KEEP (*(.preinit_array*))
     PROVIDE_HIDDEN (__preinit_array_end = .);
-  } >FLASH
+  } >BOOTROM
   .init_array :
   {
     PROVIDE_HIDDEN (__init_array_start = .);
     KEEP (*(SORT(.init_array.*)))
     KEEP (*(.init_array*))
     PROVIDE_HIDDEN (__init_array_end = .);
-  } >FLASH
+  } >BOOTROM
   .fini_array :
   {
     PROVIDE_HIDDEN (__fini_array_start = .);
     KEEP (*(SORT(.fini_array.*)))
     KEEP (*(.fini_array*))
     PROVIDE_HIDDEN (__fini_array_end = .);
-  } >FLASH
+  } >BOOTROM
 
   /* used by the startup to initialize data */
   _sidata = LOADADDR(.data);
@@ -145,7 +128,7 @@ SECTIONS
 
     . = ALIGN(4);
     _edata = .;        /* define a global symbol at data end */
-  } >RAM AT> FLASH
+  } >RAM AT> BOOTROM
 
 
   /* Uninitialized data section */

--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,7 @@ project(
 
 objcopy = find_program('objcopy')
 clang_tidy = find_program('clang-tidy')
+cat = find_program('cat')
 
 subdir('libs')
 subdir('apps')


### PR DESCRIPTION
Add bootloader that just initializes some peripherals, then writes
something to UART, then deinitializes peripherals and jumps to
application.

Also add build targets for apps with bootloader and apps without, for
flashing over CAN.
