### PR TITLE
Revert "chore(meson): compile libraries and link to executables"

### DIFF
--- a/apps/battery-monitor/meson.build
+++ b/apps/battery-monitor/meson.build
@@ -15,9 +15,8 @@ battery_monitor_src = files(
 
 battery_monitor_elf = executable(
   'battery-monitor.elf',
-  battery_monitor_src,
+  [common_libs_src, battery_monitor_src],
   include_directories: [common_libs_inc, battery_monitor_inc],
-  link_with: common_libs,
   link_depends: app_linker_script,
   link_args: ['-T@0@'.format(app_linker_script.full_path())],
 )

--- a/apps/joystick/meson.build
+++ b/apps/joystick/meson.build
@@ -9,9 +9,8 @@ joystick_src = files(
 
 joystick_elf = executable(
   'joystick.elf',
-  joystick_src,
+  [common_libs_src, joystick_src],
   include_directories: [common_libs_inc, joystick_inc],
-  link_with: common_libs,
   link_depends: app_linker_script,
   link_args: ['-T@0@'.format(app_linker_script.full_path())],
 )

--- a/apps/sbus-receiver/meson.build
+++ b/apps/sbus-receiver/meson.build
@@ -12,9 +12,8 @@ sbus_receiver_src = files(
 
 sbus_receiver_elf = executable(
   'sbus-receiver.elf',
-  sbus_receiver_src,
+  [common_libs_src, sbus_receiver_src],
   include_directories: [common_libs_inc, sbus_receiver_inc],
-  link_with: common_libs,
   link_depends: app_linker_script,
   link_args: ['-T@0@'.format(app_linker_script.full_path())],
 )

--- a/apps/servo/meson.build
+++ b/apps/servo/meson.build
@@ -13,9 +13,8 @@ servo_src = files(
 
 servo_elf = executable(
   'servo.elf',
-  servo_src,
+  [common_libs_src, servo_src],
   include_directories: [common_libs_inc, servo_inc],
-  link_with: common_libs,
   link_depends: app_linker_script,
   link_args: ['-T@0@'.format(app_linker_script.full_path())],
 )
@@ -30,9 +29,8 @@ servo_bin = custom_target(
 
 motor_elf = executable(
   'motor.elf',
-  servo_src,
+  [common_libs_src, servo_src],
   include_directories: [common_libs_inc, servo_inc],
-  link_with: common_libs,
   link_depends: app_linker_script,
   link_args: ['-T@0@'.format(app_linker_script.full_path())],
   c_args: ['-DMOTOR'],

--- a/bootloader/meson.build
+++ b/bootloader/meson.build
@@ -11,9 +11,8 @@ bootloader_linker_script = fs.copyfile(files('src' / 'bootloader.ld'))
 
 bootloader_elf = executable(
   'bootloader.elf',
-  bootloader_src,
+  [bootloader_src, common_libs_src],
   include_directories: [bootloader_inc, common_libs_inc],
-  link_with: common_libs,
   link_depends: bootloader_linker_script,
   link_args: ['-T@0@'.format(bootloader_linker_script.full_path())],
 )

--- a/libs/can-kingdom/meson.build
+++ b/libs/can-kingdom/meson.build
@@ -2,6 +2,13 @@ can_kingdom_inc = include_directories('include')
 
 can_kingdom_postmaster_src = files('src' / 'postmaster-dummy.c')
 
+can_kingdom_postmaster_native_lib = library(
+  'can-kingdom-postmaster-native',
+  can_kingdom_postmaster_src,
+  include_directories: can_kingdom_inc,
+  native: true,
+)
+
 can_kingdom_src = files(
   'src' / 'king.c',
   'src' / 'mayor.c',
@@ -11,8 +18,9 @@ can_kingdom_src = files(
 # Build native lib for unit testing
 can_kingdom_native_lib = library(
   'can-kingdom-native',
-  [can_kingdom_src, can_kingdom_postmaster_src],
+  can_kingdom_src,
   include_directories: can_kingdom_inc,
+  link_with: can_kingdom_postmaster_native_lib,
   native: true,
 )
 

--- a/libs/meson.build
+++ b/libs/meson.build
@@ -4,41 +4,18 @@ subdir('rover')
 subdir('stm32-common')
 subdir('stm32-postmaster')
 
-# All libs that depend on other libs are built here. Libs that don't have
-# dependencies are built in their respective subdir.
-
-drivers_lib = library(
-  'drivers',
-  drivers_src,
-  include_directories: [drivers_inc, stm32_common_inc],
-)
-
-freertos_lib = library(
-  'freertos',
-  freertos_src,
-  include_directories: [freertos_inc, stm32_common_inc],
-)
-
-stm32_common_lib = library(
-  'stm32-common',
-  stm32_common_src,
-  include_directories: [stm32_common_inc, drivers_inc, freertos_inc],
-  link_with: drivers_lib,
-)
-
-stm32_postmaster_lib = library(
-  'stm32-postmaster',
-  stm32_postmaster_src,
-  include_directories: [stm32_postmaster_inc, stm32_common_inc, drivers_inc, can_kingdom_inc],
-  link_with: drivers_lib,
-)
-
-can_kingdom_lib = library(
-  'can-kingdom',
+# Convenience source file list
+common_libs_src = [
   can_kingdom_src,
-  include_directories: [can_kingdom_inc, stm32_postmaster_inc],
-  link_with: stm32_postmaster_lib,
-)
+  rover_src,
+  stm32_common_src,
+  stm32_postmaster_src,
+
+  # third-party
+  drivers_src,
+  freertos_src,
+  printf_src,
+]
 
 # Convenience include dir list
 common_libs_inc = [
@@ -51,17 +28,6 @@ common_libs_inc = [
   drivers_inc,
   freertos_inc,
   printf_inc,
-]
-
-# Convenience lib list
-common_libs = [
-  can_kingdom_lib,
-  drivers_lib,
-  freertos_lib,
-  printf_lib,
-  rover_lib,
-  stm32_common_lib,
-  stm32_postmaster_lib,
 ]
 
 common_libs_tidy_files = [

--- a/libs/rover/meson.build
+++ b/libs/rover/meson.build
@@ -2,10 +2,4 @@ rover_inc = include_directories('include')
 
 rover_src = files('src' / 'rover.c')
 
-rover_lib = library(
-  'rover',
-  rover_src,
-  include_directories: rover_inc,
-)
-
 rover_tidy_files = [rover_src]

--- a/libs/third-party/meson.build
+++ b/libs/third-party/meson.build
@@ -49,8 +49,4 @@ freertos_src = files(
 
 printf_inc = include_directories('printf')
 
-printf_lib = library(
-  'printf',
-  files('printf' / 'printf.c'),
-  include_directories: printf_inc,
-)
+printf_src = files('printf' / 'printf.c')

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
   'Rover',
   'c',
   meson_version: '>=1.2.0',
-  version: '0.2.0',
+  version: '0.1',
   default_options: [
     'buildtype=debugoptimized',
     'default_library=static',


### PR DESCRIPTION
This reverts commit e5f857faae4c21d858038e6f3c58984e3179bae1.

Compiling the HAL as a static library causes issues where __weak
functions are not overridden. The reason is that when the library is
linked the first function definition found is used, which is provided
by the HAL, and the overridden function in the user application is
ignored.
