### PR TITLE
fix(stm32-common): enable auto bus-off management

### DIFF
--- a/libs/stm32-common/src/common-peripherals.c
+++ b/libs/stm32-common/src/common-peripherals.c
@@ -37,7 +37,7 @@ void can_init(void) {
   hcan->Init.TimeSeg2 = CAN_BS2_2TQ;
   hcan->Init.SyncJumpWidth = CAN_SJW_1TQ;
   hcan->Init.TimeTriggeredMode = DISABLE;
-  hcan->Init.AutoBusOff = DISABLE;
+  hcan->Init.AutoBusOff = ENABLE;
   hcan->Init.AutoWakeUp = DISABLE;
   hcan->Init.AutoRetransmission = ENABLE;
   hcan->Init.ReceiveFifoLocked = DISABLE;


### PR DESCRIPTION
Let the CAN hardware go bus on automatically once the CAN bus is free
from errors.
