### PR TITLE
fix(servo): add function for configuring both pots

### DIFF
--- a/apps/servo/include/potentiometer.h
+++ b/apps/servo/include/potentiometer.h
@@ -12,11 +12,12 @@ extern "C" {
  * The default value of POT_IVRA_DEFAULT is based on a servo with an operating
  * voltage of 6.0-8.4V.
  */
-#define POT_SERVO_DEFAULT 31  // Gives voltage of 7.4 V, standard servo voltage.
-#define POT_SENSOR_DEFAULT 40
+#define POT_SERVO_DEFAULT 32    // Gives ~7.4V, standard servo voltage.
+#define POT_SENSOR_DEFAULT 180  // Gives 3.3V
 
 void configure_servo_potentiometer(uint8_t pot_value);
 void configure_sensor_potentiometer(uint8_t pot_value);
+void configure_both_potentiometers(uint8_t servo_pot, uint8_t sensor_pot);
 
 #ifdef __cplusplus
 }

--- a/apps/servo/src/main.c
+++ b/apps/servo/src/main.c
@@ -48,8 +48,7 @@ int main(void) {
   }
 
   // Configure potentiometers
-  configure_servo_potentiometer(POT_SERVO_DEFAULT);
-  configure_sensor_potentiometer(POT_SENSOR_DEFAULT);
+  configure_both_potentiometers(POT_SERVO_DEFAULT, POT_SENSOR_DEFAULT);
 
   pwm_init();
   pwm_set_pulse(PWM_NEUTRAL_PULSE_MUS);  // Start at neutral

--- a/apps/servo/src/potentiometer.c
+++ b/apps/servo/src/potentiometer.c
@@ -20,3 +20,10 @@ void configure_sensor_potentiometer(uint8_t pot_value) {
   HAL_I2C_Master_Transmit(&peripherals->hi2c1, POT_ADDR, ivrb_write,
                           sizeof(ivrb_write), HAL_MAX_DELAY);
 }
+
+void configure_both_potentiometers(uint8_t servo_pot, uint8_t sensor_pot) {
+  peripherals_t *peripherals = get_peripherals();
+  uint8_t ivr_write[3] = {POT_IVRA_ADDR, servo_pot, sensor_pot};
+  HAL_I2C_Master_Transmit(&peripherals->hi2c1, POT_ADDR, ivr_write,
+                          sizeof(ivr_write), HAL_MAX_DELAY);
+}


### PR DESCRIPTION
Since there is a 20ms delay for writing the potentiometer registers,
causing only one of the configure functions to apply when calling them
back-to-back. To avoid this, we use a feature in the TPL0102 to write
both registers with one i2c command.
