### PR TITLE
chore(sbus-receiver): use radio switch to set trim

### DIFF
--- a/apps/sbus-receiver/src/main.c
+++ b/apps/sbus-receiver/src/main.c
@@ -9,7 +9,6 @@
 
 // CK
 #include "mayor.h"
-#include "postmaster-hal.h"
 
 // STM32Common
 #include "clock.h"

--- a/apps/sbus-receiver/src/sbus.c
+++ b/apps/sbus-receiver/src/sbus.c
@@ -2,15 +2,11 @@
 
 #include <string.h>
 
-#include "error.h"
-#include "peripherals.h"
-#include "stm32f3xx_hal.h"
-
 /*
  * The SBUS packet is 25 bytes long consisting of:
  *
  * Byte[0]: SBUS header, 0x0F
- * Byte[1 -22]: 16 servo channels, 11 bits each
+ * Byte[1-22]: 16 servo channels, 11 bits each
  * Byte[23]
  *     Bit 0: channel 17 (0x01)
  *     Bit 1: channel 18 (0x02)


### PR DESCRIPTION
Instead of guessing the trim based on movement of the knobs, let the
user explicitly set the trim by holding down a switch on channel 7 and
moving the trim knobs or the control knobs.
