### PR TITLE
chore/formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,2 @@
 BasedOnStyle: Google
+AllowShortFunctionsOnASingleLine: false

--- a/apps/battery-monitor/src/battery.c
+++ b/apps/battery-monitor/src/battery.c
@@ -43,7 +43,9 @@ void battery_state_reset(void) {
   battery_state.low_voltage_fault = false;
 }
 
-battery_state_t *get_battery_state(void) { return &battery_state; }
+battery_state_t *get_battery_state(void) {
+  return &battery_state;
+}
 
 void set_fuse_config(fuse_config_t fuse_config) {
   switch (fuse_config) {

--- a/apps/battery-monitor/src/ck-data.c
+++ b/apps/battery-monitor/src/ck-data.c
@@ -14,7 +14,9 @@ void ck_data_init(void) {
   folder_init();
 }
 
-ck_data_t* get_ck_data(void) { return &ck_data; }
+ck_data_t* get_ck_data(void) {
+  return &ck_data;
+}
 
 void page_init(void) {
   ck_data.cell_page0 = &ck_data.pages[0];

--- a/apps/battery-monitor/src/interrupts.c
+++ b/apps/battery-monitor/src/interrupts.c
@@ -11,4 +11,6 @@ void DMA2_Channel1_IRQHandler(void) {
   HAL_DMA_IRQHandler(&peripherals->hdma_adc2);
 }
 
-void EXTI15_10_IRQHandler(void) { HAL_GPIO_EXTI_IRQHandler(OVER_CURRENT_PIN); }
+void EXTI15_10_IRQHandler(void) {
+  HAL_GPIO_EXTI_IRQHandler(OVER_CURRENT_PIN);
+}

--- a/apps/battery-monitor/src/peripherals.c
+++ b/apps/battery-monitor/src/peripherals.c
@@ -18,7 +18,9 @@ void i2c1_init(void);
 void dma_init(void);
 void gpio_init(void);
 
-peripherals_t* get_peripherals(void) { return &peripherals; }
+peripherals_t* get_peripherals(void) {
+  return &peripherals;
+}
 
 void peripherals_init(void) {
   common_peripherals_init();

--- a/apps/joystick/src/peripherals.c
+++ b/apps/joystick/src/peripherals.c
@@ -14,7 +14,9 @@ void spi3_init(void);
 void dma_init(void);
 void gpio_init(void);
 
-peripherals_t* get_peripherals(void) { return &peripherals; }
+peripherals_t* get_peripherals(void) {
+  return &peripherals;
+}
 
 void peripherals_init(void) {
   common_peripherals_init();

--- a/apps/sbus-receiver/src/ck-data.c
+++ b/apps/sbus-receiver/src/ck-data.c
@@ -14,7 +14,9 @@ void ck_data_init(void) {
   folder_init();
 }
 
-ck_data_t* get_ck_data(void) { return &ck_data; }
+ck_data_t* get_ck_data(void) {
+  return &ck_data;
+}
 
 void page_init(void) {
   ck_data.steering_page = &ck_data.pages[0];

--- a/apps/sbus-receiver/src/peripherals.c
+++ b/apps/sbus-receiver/src/peripherals.c
@@ -11,7 +11,9 @@ static peripherals_t peripherals;
 void gpio_init(void);
 void uart2_init(void);
 
-peripherals_t* get_peripherals(void) { return &peripherals; }
+peripherals_t* get_peripherals(void) {
+  return &peripherals;
+}
 
 void peripherals_init(void) {
   common_peripherals_init();

--- a/apps/sbus-receiver/src/sbus.c
+++ b/apps/sbus-receiver/src/sbus.c
@@ -31,7 +31,9 @@ static void sbus_parse_packet(const sbus_packet_t *packet,
 
 static int read_uart_stream(uint8_t *dest, size_t size);
 
-void sbus_init(TaskHandle_t task_to_notify) { sbus_task = task_to_notify; }
+void sbus_init(TaskHandle_t task_to_notify) {
+  sbus_task = task_to_notify;
+}
 
 int sbus_read_message(sbus_message_t *message) {
   sbus_task = xTaskGetCurrentTaskHandle();

--- a/apps/servo/src/ck-data.c
+++ b/apps/servo/src/ck-data.c
@@ -14,7 +14,9 @@ void ck_data_init(void) {
   folder_init();
 }
 
-ck_data_t* get_ck_data(void) { return &ck_data; }
+ck_data_t* get_ck_data(void) {
+  return &ck_data;
+}
 
 void page_init(void) {
   ck_data.servo_position_page = &ck_data.pages[0];

--- a/apps/servo/src/failsafe.c
+++ b/apps/servo/src/failsafe.c
@@ -57,4 +57,6 @@ void failsafe_set_timeout(uint16_t timeout_ms) {
   failsafe_timeout = timeout_ms;
 }
 
-void failsafe_set_pulse(uint16_t pulse_mus) { failsafe_pulse = pulse_mus; }
+void failsafe_set_pulse(uint16_t pulse_mus) {
+  failsafe_pulse = pulse_mus;
+}

--- a/apps/servo/src/peripherals.c
+++ b/apps/servo/src/peripherals.c
@@ -24,7 +24,9 @@ void i2c3_init(void);
 void spi3_init(void);
 void tim1_init(void);
 
-peripherals_t* get_peripherals(void) { return &peripherals; }
+peripherals_t* get_peripherals(void) {
+  return &peripherals;
+}
 
 void peripherals_init(void) {
   common_peripherals_init();

--- a/bootloader/src/ck-data.c
+++ b/bootloader/src/ck-data.c
@@ -16,7 +16,9 @@ void ck_data_init(void) {
   folder_init();
 }
 
-ck_data_t* get_ck_data(void) { return &ck_data; }
+ck_data_t* get_ck_data(void) {
+  return &ck_data;
+}
 
 void page_init(void) {
   ck_data.bootloader_page = &ck_data.pages[0];

--- a/libs/can-kingdom/src/mayor.c
+++ b/libs/can-kingdom/src/mayor.c
@@ -381,9 +381,13 @@ ck_err_t ck_set_comm_mode(ck_comm_mode_t mode) {
   return ck_apply_comm_mode(mode);
 }
 
-ck_comm_mode_t ck_get_comm_mode(void) { return mayor.comm_mode; }
+ck_comm_mode_t ck_get_comm_mode(void) {
+  return mayor.comm_mode;
+}
 
-uint32_t ck_get_base_number(void) { return mayor.user_data.ck_id.base_no; }
+uint32_t ck_get_base_number(void) {
+  return mayor.user_data.ck_id.base_no;
+}
 
 ck_err_t ck_is_default_letter(ck_letter_t *letter) {
   ck_letter_t dletter = ck_default_letter();

--- a/libs/can-kingdom/src/postmaster-dummy.c
+++ b/libs/can-kingdom/src/postmaster-dummy.c
@@ -15,7 +15,9 @@ ck_err_t ck_apply_comm_mode(ck_comm_mode_t mode) {
   return CK_OK;
 }
 
-uint8_t ck_get_125kbit_prescaler(void) { return 1; }
+uint8_t ck_get_125kbit_prescaler(void) {
+  return 1;
+}
 
 ck_err_t ck_set_bit_timing(const ck_can_bit_timing_t *bit_timing) {
   if (!bit_timing) {

--- a/libs/can-kingdom/tests/mayor-test.c
+++ b/libs/can-kingdom/tests/mayor-test.c
@@ -1058,7 +1058,8 @@ static ck_err_t set_city_mode(ck_city_mode_t mode) {
   return CK_OK;
 }
 
-static void start_200ms_timer(void) {}
+static void start_200ms_timer(void) {
+}
 
 static test_err_t check_kings_doc_folder(ck_folder_t *folder) {
   if (folder->envelope_count != 1) {

--- a/libs/stm32-common/src/common-interrupts.c
+++ b/libs/stm32-common/src/common-interrupts.c
@@ -38,7 +38,8 @@ void UsageFault_Handler(void) {
 }
 
 // Debug monitor handler.
-void DebugMon_Handler(void) {}
+void DebugMon_Handler(void) {
+}
 
 // System tick timer handler.
 void SysTick_Handler(void) {

--- a/libs/stm32-common/src/device-id.c
+++ b/libs/stm32-common/src/device-id.c
@@ -29,7 +29,9 @@ ck_id_t get_default_ck_id(uint8_t city_address) {
   return ck_id;
 }
 
-ck_id_t *get_cached_ck_id(void) { return &cached_ck_id; }
+ck_id_t *get_cached_ck_id(void) {
+  return &cached_ck_id;
+}
 
 int read_ck_id(ck_id_t *ck_id) {
   memset(ck_id, 0, sizeof(ck_id_t));


### PR DESCRIPTION
- chore(formatting): don't allow short functions on a single line
- chore(spi-flash): use better function names
