### PR TITLE
fix(bootloader): correct cast of word to uint32_t

### DIFF
--- a/bootloader/src/main.c
+++ b/bootloader/src/main.c
@@ -465,7 +465,7 @@ static void flash_program(void *unused) {
       HAL_FLASH_Unlock();
       HAL_StatusTypeDef status = HAL_OK;
       status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_WORD, current_address,
-                                 *(uint64_t *)word);
+                                 *(uint32_t *)word);
       HAL_FLASH_Lock();
       taskEXIT_CRITICAL();
 


### PR DESCRIPTION
The HAL_FLASH_Program function takes a uint64_t for double word
programming, but since we're programming the flash using word sizes,
cast to a uint32_t instead of a uint64_t.
