### PR TITLE
fix(battery-monitor): prevent voltage spike on reg output turn on

### DIFF
--- a/apps/battery-monitor/src/battery.c
+++ b/apps/battery-monitor/src/battery.c
@@ -199,6 +199,11 @@ void update_battery_leds(void) {
 }
 
 void update_reg_out_voltage_controller(void) {
+  // Not relevant to update the controller when the reg out is off.
+  if (get_reg_out_power_state() == POWER_OFF) {
+    return;
+  }
+
   // Target voltage is set to 0 on init. Default to 5V or 12V depending on
   // jumper state.
   if (battery_state.target_reg_out_voltage == 0) {

--- a/apps/battery-monitor/src/jumpers.c
+++ b/apps/battery-monitor/src/jumpers.c
@@ -3,6 +3,7 @@
 #include "battery.h"
 #include "error.h"
 #include "potentiometer.h"
+#include "power.h"
 
 /*
  * X11 and X12 jumper configuration
@@ -51,6 +52,11 @@ uint16_t get_current_measure_jumper_r_out(void) {
 }
 
 void update_voltage_regulator_jumper_state(void) {
+  // The jumper state cannot be determined if the reg out is off.
+  if (get_reg_out_power_state() == POWER_OFF) {
+    return;
+  }
+
   battery_state_t *battery_state = get_battery_state();
   uint8_t pot_val = 0;
 

--- a/apps/battery-monitor/tests/test-battery.c
+++ b/apps/battery-monitor/tests/test-battery.c
@@ -401,6 +401,9 @@ void test_update_reg_out_voltage_controller_increase_voltage(void) {
   };
   SET_CUSTOM_FAKE_SEQ(read_potentiometer_value, custom_fakes, 2);
 
+  power_state_t reg_out_state_return_values[2] = {POWER_ON, POWER_ON};
+  SET_RETURN_SEQ(get_reg_out_power_state, reg_out_state_return_values, 2);
+
   update_reg_out_voltage_controller();
 
   ASSERT(read_potentiometer_value_fake.call_count == 1, "expected: 1, got: %u",
@@ -440,6 +443,9 @@ void test_update_reg_out_voltage_controller_decrease_voltage(void) {
   };
   SET_CUSTOM_FAKE_SEQ(read_potentiometer_value, custom_fakes, 2);
 
+  power_state_t reg_out_state_return_values[2] = {POWER_ON, POWER_ON};
+  SET_RETURN_SEQ(get_reg_out_power_state, reg_out_state_return_values, 2);
+
   update_reg_out_voltage_controller();
 
   ASSERT(write_potentiometer_value_fake.call_count == 1, "expected: 1, got: %u",
@@ -469,6 +475,9 @@ void test_update_reg_out_voltage_controller_startup_low_voltage(void) {
   const uint16_t startup_voltage = 2500;
   battery_state->reg_out.voltage = startup_voltage;
 
+  power_state_t reg_out_state_return_values[2] = {POWER_ON, POWER_ON};
+  SET_RETURN_SEQ(get_reg_out_power_state, reg_out_state_return_values, 2);
+
   update_voltage_regulator_jumper_state();
   update_reg_out_voltage_controller();
 
@@ -487,6 +496,9 @@ void test_update_reg_out_voltage_controller_startup_high_voltage(void) {
 
   const uint16_t startup_voltage = 6000;
   battery_state->reg_out.voltage = startup_voltage;
+
+  power_state_t reg_out_state_return_values[2] = {POWER_ON, POWER_ON};
+  SET_RETURN_SEQ(get_reg_out_power_state, reg_out_state_return_values, 2);
 
   update_voltage_regulator_jumper_state();
   update_reg_out_voltage_controller();


### PR DESCRIPTION
When the reg output is off, the controller was trying to compensate for
a too low voltage by increasing the output voltage pot value. This makes
the pot have the maximum value when the controller is turned on,
resulting in a voltage spike. Fixed by returning early from functions
that depend on the controller being powered on to function.
