### PR TITLE
fix(flasher): ignore error frames in node online detection

### DIFF
--- a/rover_py/flasher/flasher.py
+++ b/rover_py/flasher/flasher.py
@@ -30,7 +30,7 @@ class Flasher:
         while True:
             try:
                 frame = self.ch.read(timeout=self.default_timeout_ms)
-                if frame:
+                if frame and canlib.MessageFlag.ERROR_FRAME not in frame.flags:
                     self.online_node_ids.add(frame.id - rover.BASE_NUMBER)
 
             except (canlib.exceptions.CanTimeout, canlib.exceptions.CanNoMsg):


### PR DESCRIPTION
When two nodes with the same ID are on the bus, there will be error
frames due to the fact they try to transmit the same message at the same
time. We ignore error frames in this scenario.
