### PR TITLE
chore/meson fixes

### DIFF
--- a/apps/battery-monitor/meson.build
+++ b/apps/battery-monitor/meson.build
@@ -28,7 +28,6 @@ battery_monitor_bin = custom_target(
     output: 'battery-monitor.bin',
     input: battery_monitor_elf,
     command: [objcopy, '-O', 'binary', '-S', '@INPUT@', '@OUTPUT@'],
-    depends: battery_monitor_elf,
     build_by_default: true,
 )
 
@@ -45,6 +44,7 @@ run_target(
         '-c',
         'program @0@ verify reset exit'.format(battery_monitor_elf.full_path()),
     ],
+    depends: [bootloader_elf, battery_monitor_elf],  # required because full_path doesn't create automatic dependency on these objects
 )
 
 release_files += [battery_monitor_elf, battery_monitor_bin]

--- a/apps/brake/meson.build
+++ b/apps/brake/meson.build
@@ -24,7 +24,6 @@ brake_bin = custom_target(
     output: 'brake.bin',
     input: brake_elf,
     command: [objcopy, '-O', 'binary', '-S', '@INPUT@', '@OUTPUT@'],
-    depends: brake_elf,
     build_by_default: true,
 )
 
@@ -39,6 +38,7 @@ run_target(
         '-c',
         'program @0@ verify reset exit'.format(brake_elf.full_path()),
     ],
+    depends: [bootloader_elf, brake_elf],  # required because full_path doesn't create automatic dependency on these objects
 )
 
 release_files += [brake_elf, brake_bin]

--- a/apps/obstacle-detector/meson.build
+++ b/apps/obstacle-detector/meson.build
@@ -24,7 +24,6 @@ obstacle_detector_bin = custom_target(
     output: 'obstacle-detector.bin',
     input: obstacle_detector_elf,
     command: [objcopy, '-O', 'binary', '-S', '@INPUT@', '@OUTPUT@'],
-    depends: obstacle_detector_elf,
     build_by_default: true,
 )
 
@@ -39,6 +38,7 @@ run_target(
         '-c',
         'program @0@ verify reset exit'.format(obstacle_detector_elf.full_path()),
     ],
+    depends: [bootloader_elf, obstacle_detector_elf],  # required because full_path doesn't create automatic dependency on these objects
 )
 
 release_files += [obstacle_detector_elf, obstacle_detector_bin]

--- a/apps/sbus-receiver/meson.build
+++ b/apps/sbus-receiver/meson.build
@@ -23,7 +23,6 @@ sbus_receiver_bin = custom_target(
     output: 'sbus-receiver.bin',
     input: sbus_receiver_elf,
     command: [objcopy, '-O', 'binary', '-S', '@INPUT@', '@OUTPUT@'],
-    depends: sbus_receiver_elf,
     build_by_default: true,
 )
 
@@ -38,6 +37,7 @@ run_target(
         '-c',
         'program @0@ verify reset exit'.format(sbus_receiver_elf.full_path()),
     ],
+    depends: [bootloader_elf, sbus_receiver_elf],  # required because full_path doesn't create automatic dependency on these objects
 )
 
 release_files += [sbus_receiver_elf, sbus_receiver_bin]

--- a/apps/servo/meson.build
+++ b/apps/servo/meson.build
@@ -28,7 +28,6 @@ servo_bin = custom_target(
     output: 'servo.bin',
     input: servo_elf,
     command: [objcopy, '-O', 'binary', '-S', '@INPUT@', '@OUTPUT@'],
-    depends: servo_elf,
     build_by_default: true,
 )
 
@@ -46,7 +45,6 @@ motor_bin = custom_target(
     output: 'motor.bin',
     input: motor_elf,
     command: [objcopy, '-O', 'binary', '-S', '@INPUT@', '@OUTPUT@'],
-    depends: motor_elf,
     build_by_default: true,
 )
 
@@ -67,6 +65,7 @@ run_target(
         '-c',
         'program @0@ verify reset exit'.format(servo_elf.full_path()),
     ],
+    depends: [bootloader_elf, servo_elf],  # required because full_path doesn't create automatic dependency on these objects
 )
 
 run_target(
@@ -80,6 +79,7 @@ run_target(
         '-c',
         'program @0@ verify reset exit'.format(motor_elf.full_path()),
     ],
+    depends: [bootloader_elf, motor_elf],  # required because full_path doesn't create automatic dependency on these objects
 )
 
 release_files += [servo_elf, servo_bin, motor_elf, motor_bin]

--- a/bootloader/meson.build
+++ b/bootloader/meson.build
@@ -35,7 +35,6 @@ bootloader_bin = custom_target(
         '@INPUT@',
         '@OUTPUT@',
     ],
-    depends: bootloader_elf,
     build_by_default: true,
 )
 
@@ -48,6 +47,7 @@ run_target(
         '-c',
         'program @0@ verify reset exit'.format(bootloader_elf.full_path()),
     ],
+    depends: [bootloader_elf],  # required because full_path doesn't create automatic dependency on this object
 )
 
 release_files += [bootloader_elf, bootloader_bin]

--- a/libs/stm32-common/meson.build
+++ b/libs/stm32-common/meson.build
@@ -14,12 +14,12 @@ stm32_lib_src = files(
     'src' / 'postmaster-base.c',
     'src' / 'print.c',
     'src' / 'spi-flash.c',
-    'src' / 'syscalls.c',
-    'src' / 'sysmem.c',
 )
 
 stm32_startup_src = files(
     'src' / 'startup_stm32f302xe.s',
+    'src' / 'syscalls.c',
+    'src' / 'sysmem.c',
     'src' / 'system_stm32f3xx.c',
 )
 


### PR DESCRIPTION
- **chore(meson): fix build dependencies**
- **chore(stm32-common): move sysmem and syscall files to startup_src**
