### PR TITLE
fix(postmaster): add letter transmission timeout

### DIFF
--- a/apps/battery-monitor/src/freertos-tasks.c
+++ b/apps/battery-monitor/src/freertos-tasks.c
@@ -185,14 +185,19 @@ void update_pages(void) {
 void send_docs(void) {
   ck_data_t *ck_data = get_ck_data();
 
-  if (ck_send_document(ck_data->cell_folder->folder_no) != CK_OK) {
-    printf("failed to send doc.\r\n");
+  ck_err_t ret = ck_send_document(ck_data->cell_folder->folder_no);
+  if (ret != CK_OK && ret != CK_ERR_TIMEOUT) {
+    printf("error: failed to send cell voltage doc\r\n");
   }
-  if (ck_send_document(ck_data->reg_out_folder->folder_no) != CK_OK) {
-    printf("failed to send doc.\r\n");
+
+  ret = ck_send_document(ck_data->reg_out_folder->folder_no);
+  if (ret != CK_OK && ret != CK_ERR_TIMEOUT) {
+    printf("error: failed to send REG out doc\r\n");
   }
-  if (ck_send_document(ck_data->vbat_out_folder->folder_no) != CK_OK) {
-    printf("failed to send doc.\r\n");
+
+  ret = ck_send_document(ck_data->vbat_out_folder->folder_no);
+  if (ret != CK_OK && ret != CK_ERR_TIMEOUT) {
+    printf("error: failed to VBAT out doc\r\n");
   }
 }
 

--- a/apps/brake/src/report.c
+++ b/apps/brake/src/report.c
@@ -74,8 +74,9 @@ void report(void *unused) {
       continue;
     }
 
-    if (ck_send_document(ck_data->wheel_speed_folder->folder_no) != CK_OK) {
-      printf("failed to send doc.\r\n");
+    ck_err_t ret = ck_send_document(ck_data->wheel_speed_folder->folder_no);
+    if (ret != CK_OK && ret != CK_ERR_TIMEOUT) {
+      printf("error: failed to wheel speed doc\r\n");
     }
   }
 }

--- a/apps/obstacle-detector/src/report.c
+++ b/apps/obstacle-detector/src/report.c
@@ -74,8 +74,9 @@ void report(void *unused) {
       continue;
     }
 
-    if (ck_send_document(ck_data->object_distance_folder->folder_no) != CK_OK) {
-      printf("failed to send doc.\r\n");
+    ck_err_t ret = ck_send_document(ck_data->object_distance_folder->folder_no);
+    if (ret != CK_OK && ret != CK_ERR_TIMEOUT) {
+      printf("error: failed to send object distance doc\r\n");
     }
   }
 }

--- a/apps/sbus-receiver/src/freertos-tasks.c
+++ b/apps/sbus-receiver/src/freertos-tasks.c
@@ -91,11 +91,13 @@ void send_steering_command(steering_command_t *command) {
   memcpy(&ck_data->throttle_page->lines[1], &command->throttle,
          sizeof(command->throttle));
 
-  if (ck_send_document(ck_data->steering_folder->folder_no) != CK_OK) {
-    printf("failed to send doc.\r\n");
+  ck_err_t ret = ck_send_document(ck_data->steering_folder->folder_no);
+  if (ret != CK_OK && ret != CK_ERR_TIMEOUT) {
+    printf("error: failed to send steering doc\r\n");
   }
-  if (ck_send_document(ck_data->throttle_folder->folder_no) != CK_OK) {
-    printf("failed to send doc.\r\n");
+  ret = ck_send_document(ck_data->throttle_folder->folder_no);
+  if (ret != CK_OK && ret != CK_ERR_TIMEOUT) {
+    printf("error: failed to send throttle doc\r\n");
   }
 }
 

--- a/apps/sbus-receiver/src/steering.c
+++ b/apps/sbus-receiver/src/steering.c
@@ -176,11 +176,13 @@ static void send_subtrim_commands(void) {
   memcpy(ck_data->throttle_subtrim_page->lines, &throttle_subtrim,
          sizeof(throttle_subtrim));
 
-  if (ck_send_document(ck_data->steering_subtrim_folder->folder_no) != CK_OK) {
-    printf("failed to send doc.\r\n");
+  ck_err_t ret = ck_send_document(ck_data->steering_subtrim_folder->folder_no);
+  if (ret != CK_OK && ret != CK_ERR_TIMEOUT) {
+    printf("error: failed to send steering subtrim doc\r\n");
   }
-  if (ck_send_document(ck_data->throttle_subtrim_folder->folder_no) != CK_OK) {
-    printf("failed to send doc.\r\n");
+  ret = ck_send_document(ck_data->throttle_subtrim_folder->folder_no);
+  if (ret != CK_OK && ret != CK_ERR_TIMEOUT) {
+    printf("error: failed to send throttle subtrim doc\r\n");
   }
 }
 

--- a/apps/servo/src/freertos-tasks.c
+++ b/apps/servo/src/freertos-tasks.c
@@ -151,20 +151,29 @@ void report_timer(TimerHandle_t timer) {
 void send_docs(void) {
   ck_data_t *ck_data = get_ck_data();
 
-  if (ck_send_document(ck_data->servo_position_folder->folder_no) != CK_OK) {
-    printf("failed to send doc.\r\n");
+  ck_err_t ret = ck_send_document(ck_data->servo_position_folder->folder_no);
+  if (ret != CK_OK && ret != CK_ERR_TIMEOUT) {
+    printf("error: failed to send servo position doc\r\n");
   }
-  if (ck_send_document(ck_data->servo_current_folder->folder_no) != CK_OK) {
-    printf("failed to send doc.\r\n");
+
+  ret = ck_send_document(ck_data->servo_current_folder->folder_no);
+  if (ret != CK_OK && ret != CK_ERR_TIMEOUT) {
+    printf("error: failed to send servo current doc\r\n");
   }
-  if (ck_send_document(ck_data->battery_voltage_folder->folder_no) != CK_OK) {
-    printf("failed to send doc.\r\n");
+
+  ret = ck_send_document(ck_data->battery_voltage_folder->folder_no);
+  if (ret != CK_OK && ret != CK_ERR_TIMEOUT) {
+    printf("error: failed to send battery voltage doc\r\n");
   }
-  if (ck_send_document(ck_data->servo_voltage_folder->folder_no) != CK_OK) {
-    printf("failed to send doc.\r\n");
+
+  ret = ck_send_document(ck_data->servo_voltage_folder->folder_no);
+  if (ret != CK_OK && ret != CK_ERR_TIMEOUT) {
+    printf("error: failed to send servo voltage doc\r\n");
   }
-  if (ck_send_document(ck_data->h_bridge_current_folder->folder_no) != CK_OK) {
-    printf("failed to send doc.\r\n");
+
+  ret = ck_send_document(ck_data->h_bridge_current_folder->folder_no);
+  if (ret != CK_OK && ret != CK_ERR_TIMEOUT) {
+    printf("error: failed to send H-bridge current doc\r\n");
   }
 }
 

--- a/libs/can-kingdom/include/ck-types.h
+++ b/libs/can-kingdom/include/ck-types.h
@@ -172,6 +172,10 @@ typedef enum {
   CK_ERR_PERIPHERAL,
   /// Input argument to function is wrong in some way.
   CK_ERR_INVALID_PARAMETER,
+  /// Undefined error in user-defined function.
+  CK_ERR_USER,
+  /// Function exited due to timeout.
+  CK_ERR_TIMEOUT,
 } ck_err_t;
 
 /// Supported king's pages.

--- a/libs/can-kingdom/include/postmaster.h
+++ b/libs/can-kingdom/include/postmaster.h
@@ -19,6 +19,21 @@ extern "C" {
 #include "ck-types.h"
 
 /*******************************************************************************
+ * Initialize the postmaster.
+ *
+ * Should be provided by the implementation if anything needs to be initialized
+ * before starting CAN communication.
+ *
+ * This function is called by ck_mayor_init() and should not be called directly
+ * by the user applicaiton.
+ *
+ * @return #CK_ERR_USER if init fails.
+ *
+ * @return #CK_OK on success.
+ ******************************************************************************/
+ck_err_t ck_postmaster_init(void);
+
+/*******************************************************************************
  * Try to send a letter.
  *
  * This function should not be called directly by the user applicaiton, use

--- a/libs/can-kingdom/src/mayor.c
+++ b/libs/can-kingdom/src/mayor.c
@@ -125,6 +125,11 @@ ck_err_t ck_mayor_init(const ck_mayor_t *mayor_) {
     return ret;
   }
 
+  ret = ck_postmaster_init();
+  if (ret != CK_OK) {
+    return ret;
+  }
+
   mayor.comm_mode = CK_COMM_MODE_SILENT;
   mayor.comm_flags = CK_COMM_RESET;
 
@@ -253,8 +258,10 @@ ck_err_t ck_send_document(uint8_t folder_no) {
     letter.envelope = folder->envelopes[i];
     for (int j = 0; j < doc->page_count; j++) {
       memcpy(&letter.page, doc->pages[j], sizeof(ck_page_t));
-      if (ck_send_letter(&letter) != CK_OK) {
-        return CK_ERR_SEND_FAILED;
+
+      ck_err_t ret = ck_send_letter(&letter);
+      if (ret != CK_OK) {
+        return ret;
       }
     }
   }
@@ -305,10 +312,13 @@ ck_err_t ck_send_page(uint8_t folder_no, uint8_t page_no) {
     if (!folder->envelopes[i].enable) {
       continue;
     }
+
     letter.envelope = folder->envelopes[i];
     memcpy(&letter.page, doc->pages[page_no], sizeof(ck_page_t));
-    if (ck_send_letter(&letter) != CK_OK) {
-      return CK_ERR_SEND_FAILED;
+
+    ck_err_t ret = ck_send_letter(&letter);
+    if (ret != CK_OK) {
+      return ret;
     }
   }
   return CK_OK;
@@ -342,9 +352,12 @@ ck_err_t ck_send_mayors_page(uint8_t page_no) {
     if (!folder->envelopes[i].enable) {
       continue;
     }
+
     letter.envelope = folder->envelopes[i];
-    if (ck_send_letter(&letter) != CK_OK) {
-      return CK_ERR_SEND_FAILED;
+
+    ck_err_t ret = ck_send_letter(&letter);
+    if (ret != CK_OK) {
+      return ret;
     }
   }
   return CK_OK;
@@ -653,9 +666,9 @@ static ck_err_t process_kp1(const ck_page_t *page) {
       .is_remote = false,
   };
 
-  ck_err_t err = ck_check_envelope(&mayors_envelope);
-  if (err != CK_OK) {
-    return err;
+  ck_err_t ret = ck_check_envelope(&mayors_envelope);
+  if (ret != CK_OK) {
+    return ret;
   }
 
   mayor.user_data.folders[CK_MAYORS_FOLDER_NO].envelopes[0] = mayors_envelope;
@@ -687,9 +700,9 @@ static ck_err_t process_kp2(const ck_page_t *page) {
   // NOLINTEND(*-magic-numbers)
 
   // Bounds check
-  ck_err_t err = ck_check_envelope(&envelope);
-  if (err != CK_OK) {
-    return err;
+  ck_err_t ret = ck_check_envelope(&envelope);
+  if (ret != CK_OK) {
+    return ret;
   }
 
   switch (envelope_action) {

--- a/libs/can-kingdom/tests/postmaster-mock.c
+++ b/libs/can-kingdom/tests/postmaster-mock.c
@@ -3,6 +3,10 @@
 static ck_can_bit_timing_t current_bit_timing;
 static ck_can_bit_timing_t saved_bit_timing;
 
+ck_err_t ck_postmaster_init(void) {
+  return CK_OK;
+}
+
 ck_err_t ck_send_letter(const ck_letter_t *letter) {
   (void)letter;
   return CK_OK;

--- a/libs/rover/src/rover-helpers.c
+++ b/libs/rover/src/rover-helpers.c
@@ -20,17 +20,17 @@ static ck_envelope_t kings_envelope = {
 
 ck_err_t send_default_letter(void) {
   // Spoof a default letter reception
-  ck_err_t err = ck_default_letter_received();
-  if (err != CK_OK) {
-    printf("Error: failed to receive default letter: %d\r\n", err);
-    return err;
+  ck_err_t ret = ck_default_letter_received();
+  if (ret != CK_OK) {
+    printf("Error: failed to receive default letter: %d\r\n", ret);
+    return ret;
   }
 
   ck_letter_t default_letter = ck_default_letter();
-  err = ck_send_letter(&default_letter);
-  if (err != CK_OK) {
-    printf("Error: failed to send default letter: %d\r\n", err);
-    return err;
+  ret = ck_send_letter(&default_letter);
+  if (ret != CK_OK) {
+    printf("Error: failed to send default letter: %d\r\n", ret);
+    return ret;
   }
 
   return CK_OK;
@@ -49,10 +49,10 @@ ck_err_t assign_rover_envelopes(const ck_id_t *own_id) {
         .folder_no = kingdom->assignments[i].folder,
         .envelope_action = CK_ENVELOPE_ASSIGN,
     };
-    ck_err_t err = ck_create_kings_page_2(&kp2_args, &page);
-    if (err != CK_OK) {
-      printf("Error: failed to create king's page: %d.\r\n", err);
-      return err;
+    ck_err_t ret = ck_create_kings_page_2(&kp2_args, &page);
+    if (ret != CK_OK) {
+      printf("Error: failed to create king's page: %d.\r\n", ret);
+      return ret;
     }
 
     ck_letter_t letter = {
@@ -63,17 +63,17 @@ ck_err_t assign_rover_envelopes(const ck_id_t *own_id) {
     // Letters meant for us need to be processed internally,
     // since we can't receive the messages we send.
     if (kingdom->assignments[i].city == own_id->city_address) {
-      err = ck_process_kings_letter(&letter);
-      if (err != CK_OK) {
-        printf("Error: failed to assign envelope to self: %d.\r\n", err);
-        return err;
+      ret = ck_process_kings_letter(&letter);
+      if (ret != CK_OK) {
+        printf("Error: failed to assign envelope to self: %d.\r\n", ret);
+        return ret;
       }
     }
 
-    err = ck_send_letter(&letter);
-    if (err != CK_OK) {
-      printf("Error: failed to assign envelope: %d\r\n", err);
-      return err;
+    ret = ck_send_letter(&letter);
+    if (ret != CK_OK) {
+      printf("Error: failed to assign envelope: %d\r\n", ret);
+      return ret;
     }
   }
 
@@ -88,10 +88,10 @@ ck_err_t set_rover_base_number(void) {
       .has_extended_id = false,
       .mayor_response_no = 0,
   };
-  ck_err_t err = ck_create_kings_page_1(&kp1_args, &page);
-  if (err != CK_OK) {
-    printf("Error: failed to create king's page: %d.\r\n", err);
-    return err;
+  ck_err_t ret = ck_create_kings_page_1(&kp1_args, &page);
+  if (ret != CK_OK) {
+    printf("Error: failed to create king's page: %d.\r\n", ret);
+    return ret;
   }
 
   ck_letter_t letter = {
@@ -100,16 +100,16 @@ ck_err_t set_rover_base_number(void) {
   };
 
   // Send base number to self
-  err = ck_process_kings_letter(&letter);
-  if (err != CK_OK) {
-    printf("Error: couldn't send base number letter to self: %d.\r\n", err);
-    return err;
+  ret = ck_process_kings_letter(&letter);
+  if (ret != CK_OK) {
+    printf("Error: couldn't send base number letter to self: %d.\r\n", ret);
+    return ret;
   }
 
-  err = ck_send_letter(&letter);
-  if (err != CK_OK) {
-    printf("Error: couldn't send base number letter: %d.\r\n", err);
-    return err;
+  ret = ck_send_letter(&letter);
+  if (ret != CK_OK) {
+    printf("Error: couldn't send base number letter: %d.\r\n", ret);
+    return ret;
   }
 
   return CK_OK;
@@ -132,10 +132,10 @@ ck_err_t configure_rover_settings(void) {
       .envelope = reverse_envelope,
   };
 
-  ck_err_t err = ck_send_letter(&letter);
-  if (err != CK_OK) {
-    printf("Error: failed to send servo reverse letter: %d\r\n", err);
-    return err;
+  ck_err_t ret = ck_send_letter(&letter);
+  if (ret != CK_OK) {
+    printf("Error: failed to send servo reverse letter: %d\r\n", ret);
+    return ret;
   }
 
   return CK_OK;
@@ -149,10 +149,10 @@ ck_err_t start_communication(void) {
       .action_mode = CK_ACTION_MODE_KEEP_CURRENT,
       .comm_mode = CK_COMM_MODE_COMMUNICATE,
   };
-  ck_err_t err = ck_create_kings_page_0(&kp0_args, &page);
-  if (err != CK_OK) {
-    printf("Error: failed to create king's page: %d.\r\n", err);
-    return err;
+  ck_err_t ret = ck_create_kings_page_0(&kp0_args, &page);
+  if (ret != CK_OK) {
+    printf("Error: failed to create king's page: %d.\r\n", ret);
+    return ret;
   }
 
   ck_letter_t letter = {
@@ -160,16 +160,16 @@ ck_err_t start_communication(void) {
       .page = page,
   };
 
-  err = ck_process_kings_letter(&letter);
-  if (err != CK_OK) {
-    printf("Error: failed to send start command to self: %d.\r\n", err);
-    return err;
+  ret = ck_process_kings_letter(&letter);
+  if (ret != CK_OK) {
+    printf("Error: failed to send start command to self: %d.\r\n", ret);
+    return ret;
   }
 
-  err = ck_send_letter(&letter);
-  if (err != CK_OK) {
-    printf("Error: failed to send start command: %d\r\n", err);
-    return err;
+  ret = ck_send_letter(&letter);
+  if (ret != CK_OK) {
+    printf("Error: failed to send start command: %d\r\n", ret);
+    return ret;
   }
 
   return CK_OK;

--- a/libs/rover/src/rover.c
+++ b/libs/rover/src/rover.c
@@ -43,36 +43,36 @@ static void king(void *unused) {
     // Task will never be resumed
   }
 
-  ck_err_t err = CK_OK;
+  ck_err_t ret = CK_OK;
 
   // Send default letter several times to make sure everyone receives it.
   for (uint8_t i = 0; i < 5; i++) {  // NOLINT(*-magic-numbers)
-    err = send_default_letter();
-    if (err != CK_OK) {
+    ret = send_default_letter();
+    if (ret != CK_OK) {
       error();
     }
     vTaskDelay(pdMS_TO_TICKS(1));
   }
 
-  err = set_rover_base_number();
-  if (err != CK_OK) {
+  ret = set_rover_base_number();
+  if (ret != CK_OK) {
     error();
   }
 
   vTaskDelay(pdMS_TO_TICKS(50));  // Give cities time to respond
 
-  err = assign_rover_envelopes(get_cached_ck_id());
-  if (err != CK_OK) {
+  ret = assign_rover_envelopes(get_cached_ck_id());
+  if (ret != CK_OK) {
     error();
   }
 
-  err = configure_rover_settings();
-  if (err != CK_OK) {
+  ret = configure_rover_settings();
+  if (ret != CK_OK) {
     error();
   }
 
-  err = start_communication();
-  if (err != CK_OK) {
+  ret = start_communication();
+  if (ret != CK_OK) {
     error();
   }
 

--- a/libs/stm32-common/include/common-interrupts.h
+++ b/libs/stm32-common/include/common-interrupts.h
@@ -15,6 +15,7 @@ void SysTick_Handler(void);
 
 void USART1_IRQHandler(void);
 void USB_LP_CAN_RX0_IRQHandler(void);
+void USB_HP_CAN_TX_IRQHandler(void);
 
 #ifdef __cplusplus
 }

--- a/libs/stm32-common/src/common-interrupts.c
+++ b/libs/stm32-common/src/common-interrupts.c
@@ -62,3 +62,8 @@ void USB_LP_CAN_RX0_IRQHandler(void) {
   common_peripherals_t *common_peripherals = get_common_peripherals();
   HAL_CAN_IRQHandler(&common_peripherals->hcan);
 }
+
+void USB_HP_CAN_TX_IRQHandler(void) {
+  common_peripherals_t *common_peripherals = get_common_peripherals();
+  HAL_CAN_IRQHandler(&common_peripherals->hcan);
+}

--- a/libs/stm32-common/src/common-peripherals.c
+++ b/libs/stm32-common/src/common-peripherals.c
@@ -5,6 +5,7 @@
 
 #define USART1_IRQ_PRIORITY 5
 #define USB_LP_CAN_RX0_IRQ_PRIORITY 5
+#define USB_HP_CAN_TX_IRQ_PRIORITY 5
 #define PENDSV_IRQ_PRIORITY 15
 
 static common_peripherals_t common_peripherals;
@@ -164,6 +165,8 @@ void can_msp_init(void) {
   /* CAN interrupt Init */
   HAL_NVIC_SetPriority(USB_LP_CAN_RX0_IRQn, USB_LP_CAN_RX0_IRQ_PRIORITY, 0);
   HAL_NVIC_EnableIRQ(USB_LP_CAN_RX0_IRQn);
+  HAL_NVIC_SetPriority(USB_HP_CAN_TX_IRQn, USB_HP_CAN_TX_IRQ_PRIORITY, 0);
+  HAL_NVIC_EnableIRQ(USB_HP_CAN_TX_IRQn);
 }
 
 void can_msp_deinit(void) {


### PR DESCRIPTION
Fix issue where nodes not connected to the CAN bus will block forever
waiting for CAN transmission to succeed.

- Change the CK implementation to support an init function for the
  postmaster for setting up any needed data.
- Add new error codes CK_ERR_USER and CK_ERR_TIMEOUT for init errors and
  transmission timeout, respectively.
- Use counting semaphore to keep track of CAN mailbox availability in
  postmaster, block for maximum 10 ms before erroring out due to timeout.
- Enable CAN TX interrupt to give back semaphore.
- Adjust apps to not print messages on timeout to avoid excessive fault
  printing over UART.
