### PR TITLE
fix(rover_py): fix test include paths and fix test_change_bitrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,24 @@ For more documentation, visit [CanEduDev's Documentation website](https://www.ca
 
 Feel free to submit issues if anything is unclear.
 
-## Building the Board Applications
+## Working with the repository
 
 This project is built using [Meson](https://mesonbuild.com/) with the Ninja backend.
 
 Supported OS: Ubuntu 24.04. If you're using Windows, you can utilize the Ubuntu 24.04 [WSL](https://learn.microsoft.com/en-us/windows/wsl/) distribution.
 
-### Build Steps
+### Prerequisites
 
 1. Run `./scripts/bootstrap.sh` to set up the build environment. This step installs all dependencies and prepares the build folder.
-2. Execute `meson compile -C build` to initiate the build process.
-3. The build output can be found in the `build` folder.
+2. Enter virtual environment: `source .venv/bin/activate`
 
-## ROS2 Gateway
+It is required to activate the virtual environment to run most tasks in the repo. As such, all the next sections assume the environment has been sourced.
+
+## Building the Firmware
+
+Execute `meson compile -C build` to initiate the build process. The build output can be found in the `build` folder.
+
+## Building the ROS2 Gateway
 
 There is a ROS gateway available which exposes the Rover's CAN messages as ROS topics, and allows the user to control the Rover via ROS. The gateway is deployed as a docker container and available as part of this repository's Github packages.
 
@@ -38,7 +43,7 @@ To run all unit tests, execute `meson test -C build`.
 
 Additionally, there are integration tests that run against the boards. Note that these tests require hardware that supports canlib, such as the [Kvaser Leaf Light](https://www.kvaser.com/product/kvaser-leaf-light-hs-v2/).
 
-The integration tests are found in `rover_py/tests`. To run a test from the repo root directory run `python -m rover_py.tests.<test_name>`. Make sure to omit the `.py` file extension.
+The integration tests are found in `rover_py/tests`. They can be run using `python <path-to-test>.py`.
 
 ## Using STM32CubeMX to Generate Code
 

--- a/rover_py/tests/test_battery_conf.py
+++ b/rover_py/tests/test_battery_conf.py
@@ -2,7 +2,7 @@ import time
 
 from canlib import canlib
 
-from ..rover import Envelope, battery, rover
+from rover import Envelope, battery, rover
 
 with canlib.openChannel(
     channel=0,

--- a/rover_py/tests/test_battery_stress.py
+++ b/rover_py/tests/test_battery_stress.py
@@ -5,7 +5,7 @@ import time
 import numpy
 from canlib import canlib, kvadblib
 
-from ..rover import battery, rover
+from rover import battery, rover
 
 # Test uses 3S battery, capacity 6000mAh and discharge rate 70C.
 #

--- a/rover_py/tests/test_brake_conf.py
+++ b/rover_py/tests/test_brake_conf.py
@@ -2,7 +2,7 @@ import time
 
 from canlib import canlib
 
-from ..rover import Envelope, brake, rover
+from rover import Envelope, brake, rover
 
 with canlib.openChannel(
     channel=0,

--- a/rover_py/tests/test_braking.py
+++ b/rover_py/tests/test_braking.py
@@ -2,7 +2,7 @@ from time import sleep
 
 from canlib import canlib
 
-from ..rover import City, rover, servo
+from rover import City, rover, servo
 
 with canlib.openChannel(
     channel=0,

--- a/rover_py/tests/test_change_bitrate.py
+++ b/rover_py/tests/test_change_bitrate.py
@@ -3,7 +3,7 @@ from time import sleep
 
 from canlib import canlib
 
-from ..rover import rover
+from rover import rover
 
 try:
     # Start with 125 kbit/s
@@ -15,18 +15,20 @@ try:
         ch.setBusOutputControl(canlib.Driver.NORMAL)
         ch.busOn()
 
+        timeout = 1000
+
         # Send multiple default letters to make sure every node receives one at startup
         for _ in range(5):
-            ch.writeWait(rover.default_letter(), 100)
-            sleep(0.1)
+            ch.writeWait(rover.default_letter(), timeout)
+            sleep(0.05)
 
-        ch.writeWait(rover.give_base_number(), 100)
-        frame = ch.read(timeout=1000)
+        ch.writeWait(rover.give_base_number(), timeout)
+        frame = ch.read(timeout=timeout)
         sleep(0.5)  # Wait for responses
 
         # Switch to 500 kbit/s
         print("Switching to 500 kbit/s")
-        ch.writeWait(rover.change_bitrate_500kbit(), 100)
+        ch.writeWait(rover.change_bitrate_500kbit(), timeout)
         ch.writeWait(
             rover.restart_communication(
                 skip_startup=True, comm_mode=rover.CommMode.COMMUNICATE
@@ -39,24 +41,28 @@ try:
         sleep(0.1)  # give time for changing bitrate
         ch.busOn()
 
-        ch.writeWait(rover.default_letter(), 1000)
-        ch.writeWait(rover.give_base_number(), 100)
-        frame = ch.read(timeout=1000)
+        ch.writeWait(rover.default_letter(), timeout)
+        ch.writeWait(rover.give_base_number(), timeout)
+        frame = ch.read(timeout=timeout)
         sleep(0.5)  # Wait for responses
 
-        # print("Switching to 125 kbit/s")
-        # ch.writeWait(rover.change_bitrate_125kbit(), 100)
-        # ch.writeWait(rover.restart_communication(), 100)
+        print("Switching to 125 kbit/s")
+        ch.writeWait(rover.change_bitrate_125kbit(), timeout)
+        ch.writeWait(
+            rover.restart_communication(
+                skip_startup=True, comm_mode=rover.CommMode.COMMUNICATE
+            ),
+            timeout,
+        )
 
-        # ch.busOff()
-        # ch.setBusParams(canlib.Bitrate.BITRATE_125K)
-        # sleep(0.1)  # give time for changing bitrate
-        # ch.busOn()
+        ch.busOff()
+        ch.setBusParams(canlib.Bitrate.BITRATE_125K)
+        ch.busOn()
 
-        # ch.writeWait(rover.default_letter(), 1000)
-        # ch.writeWait(rover.give_base_number(), 100)
-        # frame = ch.read(timeout=1000)
-        # sleep(0.5)  # Wait for responses
+        ch.writeWait(rover.default_letter(), timeout)
+        ch.writeWait(rover.give_base_number(), timeout)
+        frame = ch.read(timeout=timeout)
+        sleep(0.5)  # Wait for responses
 
         print("Done")
 
@@ -65,4 +71,5 @@ except canlib.exceptions.CanTimeout:
         "Test timed out. make sure node is on the CAN bus and has a starting bitrate of 125kbit/s",
         file=sys.stderr,
     )
+
     sys.exit(1)

--- a/rover_py/tests/test_radio_detection.py
+++ b/rover_py/tests/test_radio_detection.py
@@ -3,7 +3,7 @@ import time
 import keyboard
 from canlib import canlib
 
-from ..rover import Envelope, rover, servo
+from rover import Envelope, rover, servo
 
 with canlib.openChannel(
     channel=0,

--- a/rover_py/tests/test_servo_conf.py
+++ b/rover_py/tests/test_servo_conf.py
@@ -2,7 +2,7 @@ import time
 
 from canlib import canlib
 
-from ..rover import Envelope, rover, servo
+from rover import Envelope, rover, servo
 
 with canlib.openChannel(
     channel=0,


### PR DESCRIPTION
Switch from relative include paths to normal include paths since that
works now with uv. Also, fix the test_change_bitrate test so it returns
to 125kbit after test.
