### PR TITLE
fix(ros-gateway): adjust enum parsing for ROS Humble

### DIFF
--- a/ros2/src/gateway/gateway/battery_node.py
+++ b/ros2/src/gateway/gateway/battery_node.py
@@ -25,7 +25,10 @@ class BatteryNode(Node):
 
         position = self.get_parameter("position").get_parameter_value().string_value
 
-        if position not in BatteryPosition:
+        # Workaround for ROS Humble (python 3.10) which doesn't support StrEnum natively.
+        valid_positions = [pos.value for pos in BatteryPosition]
+
+        if position not in valid_positions:
             raise ValueError()
 
         self.position = BatteryPosition(position)

--- a/ros2/src/gateway/gateway/obstacle_detector_node.py
+++ b/ros2/src/gateway/gateway/obstacle_detector_node.py
@@ -24,7 +24,10 @@ class ObstacleDetectorNode(Node):
 
         position = self.get_parameter("position").get_parameter_value().string_value
 
-        if position not in ObstacleDetectorPosition:
+        # Workaround for ROS Humble (python 3.10) which doesn't support StrEnum natively.
+        valid_positions = [pos.value for pos in ObstacleDetectorPosition]
+
+        if position not in valid_positions:
             raise ValueError()
 
         self.position = ObstacleDetectorPosition(position)

--- a/ros2/src/gateway/gateway/wheel_node.py
+++ b/ros2/src/gateway/gateway/wheel_node.py
@@ -27,7 +27,10 @@ class WheelNode(Node):
 
         position = self.get_parameter("position").get_parameter_value().string_value
 
-        if position not in WheelPosition:
+        # Workaround for ROS Humble (python 3.10) which doesn't support StrEnum natively.
+        valid_positions = [pos.value for pos in WheelPosition]
+
+        if position not in valid_positions:
             raise ValueError()
 
         self.position = WheelPosition(position)


### PR DESCRIPTION
ROS Humble runs on python 3.10 which doesn't support StrEnum, so add a
workaround where valid enum values are listed and used in validation.
