### PR TITLE
fix(peripherals): initialize HAL structures to zero

### DIFF
--- a/apps/battery-monitor/src/peripherals.c
+++ b/apps/battery-monitor/src/peripherals.c
@@ -34,7 +34,7 @@ void peripherals_init(void) {
 }
 
 void adc1_init(void) {
-  ADC_ChannelConfTypeDef config;
+  ADC_ChannelConfTypeDef config = {0};
   ADC_HandleTypeDef* hadc1 = &peripherals.hadc1;
 
   ADC12_COMMON->CCR |= ADC12_CCR_VREFEN;
@@ -109,7 +109,7 @@ void adc1_init(void) {
 }
 
 void adc2_init(void) {
-  ADC_ChannelConfTypeDef config;
+  ADC_ChannelConfTypeDef config = {0};
   ADC_HandleTypeDef* hadc2 = &peripherals.hadc2;
 
   // Common config for all channels
@@ -223,7 +223,7 @@ void dma_init(void) {
 }
 
 void gpio_init(void) {
-  GPIO_InitTypeDef gpio_init;
+  GPIO_InitTypeDef gpio_init = {0};
 
   /* GPIO Ports Clock Enable */
   __HAL_RCC_GPIOC_CLK_ENABLE();
@@ -308,7 +308,7 @@ void adc2_dma_init(ADC_HandleTypeDef* hadc) {
  * @retval None
  */
 void HAL_ADC_MspInit(ADC_HandleTypeDef* hadc) {
-  GPIO_InitTypeDef gpio_init;
+  GPIO_InitTypeDef gpio_init = {0};
   if (hadc->Instance == ADC1) {
     /* Peripheral clock enable */
     hal_rcc_adc12_clk_enabled++;
@@ -448,7 +448,7 @@ void HAL_CAN_MspDeInit(CAN_HandleTypeDef* hcan) {
  * @retval None
  */
 void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c) {
-  GPIO_InitTypeDef gpio_init;
+  GPIO_InitTypeDef gpio_init = {0};
   if (hi2c->Instance == I2C1) {
     __HAL_RCC_GPIOB_CLK_ENABLE();
     /**I2C1 GPIO Configuration

--- a/apps/light-array/src/peripherals.c
+++ b/apps/light-array/src/peripherals.c
@@ -32,7 +32,7 @@ void gpio_init(void) {
   HAL_GPIO_WritePin(GPIOB, LIGHT_3_PIN | LIGHT_4_PIN | VDD_IO_LEVEL_PIN,
                     GPIO_PIN_RESET);
 
-  GPIO_InitTypeDef gpio_init;
+  GPIO_InitTypeDef gpio_init = {0};
   gpio_init.Pin = LIGHT_1_PIN | LIGHT_2_PIN;
   gpio_init.Mode = GPIO_MODE_OUTPUT_PP;
   gpio_init.Pull = GPIO_NOPULL;

--- a/apps/obstacle-detector/src/peripherals.c
+++ b/apps/obstacle-detector/src/peripherals.c
@@ -34,7 +34,7 @@ void gpio_init(void) {
   __HAL_RCC_GPIOA_CLK_ENABLE();
   __HAL_RCC_GPIOB_CLK_ENABLE();
 
-  GPIO_InitTypeDef gpio_init;
+  GPIO_InitTypeDef gpio_init = {0};
   gpio_init.Pin = VDD_IO_LEVEL_PIN;
   gpio_init.Mode = GPIO_MODE_OUTPUT_PP;
   gpio_init.Pull = GPIO_NOPULL;
@@ -47,8 +47,8 @@ void gpio_init(void) {
 
 void adc1_init(void) {
   ADC_HandleTypeDef* hadc1 = &peripherals.hadc1;
-  ADC_MultiModeTypeDef multimode;
-  ADC_ChannelConfTypeDef config;
+  ADC_MultiModeTypeDef multimode = {0};
+  ADC_ChannelConfTypeDef config = {0};
 
   /** Common config
    */
@@ -156,7 +156,7 @@ void adc1_dma_init(ADC_HandleTypeDef* hadc) {
  * @retval None
  */
 void HAL_ADC_MspInit(ADC_HandleTypeDef* hadc) {
-  GPIO_InitTypeDef gpio_init;
+  GPIO_InitTypeDef gpio_init = {0};
   if (hadc->Instance == ADC1) {
     /* Peripheral clock enable */
     hal_rcc_adc12_clk_enabled++;

--- a/apps/sbus-receiver/src/peripherals.c
+++ b/apps/sbus-receiver/src/peripherals.c
@@ -32,7 +32,7 @@ void gpio_init(void) {
 
   HAL_GPIO_WritePin(VDD_IO_LEVEL_GPIO_PORT, VDD_IO_LEVEL_PIN, GPIO_PIN_RESET);
 
-  GPIO_InitTypeDef gpio_init;
+  GPIO_InitTypeDef gpio_init = {0};
   gpio_init.Pin = VDD_IO_LEVEL_PIN;
   gpio_init.Mode = GPIO_MODE_OUTPUT_PP;
   gpio_init.Pull = GPIO_NOPULL;
@@ -125,7 +125,7 @@ void HAL_UART_MspInit(UART_HandleTypeDef* huart) {
     uart1_msp_init();
 
   } else if (huart->Instance == USART2) {
-    GPIO_InitTypeDef gpio_init;
+    GPIO_InitTypeDef gpio_init = {0};
     /* Peripheral clock enable */
     __HAL_RCC_USART2_CLK_ENABLE();
 

--- a/apps/servo/src/peripherals.c
+++ b/apps/servo/src/peripherals.c
@@ -45,8 +45,8 @@ void peripherals_init(void) {
 
 void adc1_init(void) {
   ADC_HandleTypeDef* hadc1 = &peripherals.hadc1;
-  ADC_MultiModeTypeDef multimode;
-  ADC_ChannelConfTypeDef config;
+  ADC_MultiModeTypeDef multimode = {0};
+  ADC_ChannelConfTypeDef config = {0};
 
   /** Common config
    */
@@ -110,7 +110,7 @@ void adc1_init(void) {
 
 void adc2_init(void) {
   ADC_HandleTypeDef* hadc2 = &peripherals.hadc2;
-  ADC_ChannelConfTypeDef config;
+  ADC_ChannelConfTypeDef config = {0};
 
   /** Common config
    */
@@ -236,8 +236,8 @@ void spi3_init(void) {
 
 void tim1_init(void) {
   TIM_HandleTypeDef* htim1 = &peripherals.htim1;
-  TIM_ClockConfigTypeDef clock_source_config;
-  TIM_OC_InitTypeDef config_oc;
+  TIM_ClockConfigTypeDef clock_source_config = {0};
+  TIM_OC_InitTypeDef config_oc = {0};
 
   htim1->Instance = TIM1;
   htim1->Init.Prescaler = PWM_PSC_1MHZ;
@@ -269,7 +269,7 @@ void tim1_init(void) {
     error();
   }
 
-  GPIO_InitTypeDef gpio_init;
+  GPIO_InitTypeDef gpio_init = {0};
   __HAL_RCC_GPIOC_CLK_ENABLE();
   /**TIM1 GPIO Configuration
   PC3     ------> TIM1_CH4
@@ -297,7 +297,7 @@ void dma_init(void) {
 }
 
 void gpio_init(void) {
-  GPIO_InitTypeDef gpio_init;
+  GPIO_InitTypeDef gpio_init = {0};
 
   /* GPIO Ports Clock Enable */
   __HAL_RCC_GPIOF_CLK_ENABLE();
@@ -366,7 +366,7 @@ void adc2_dma_init(ADC_HandleTypeDef* hadc) {
  * @retval None
  */
 void HAL_ADC_MspInit(ADC_HandleTypeDef* hadc) {
-  GPIO_InitTypeDef gpio_init;
+  GPIO_InitTypeDef gpio_init = {0};
   if (hadc->Instance == ADC1) {
     /* Peripheral clock enable */
     hal_rcc_adc12_clk_enabled++;
@@ -479,7 +479,7 @@ void HAL_CAN_MspDeInit(CAN_HandleTypeDef* hcan) {
  * @retval None
  */
 void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c) {
-  GPIO_InitTypeDef gpio_init;
+  GPIO_InitTypeDef gpio_init = {0};
   if (hi2c->Instance == I2C1) {
     __HAL_RCC_GPIOB_CLK_ENABLE();
     /**I2C1 GPIO Configuration
@@ -560,7 +560,7 @@ void HAL_I2C_MspDeInit(I2C_HandleTypeDef* hi2c) {
  * @retval None
  */
 void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi) {
-  GPIO_InitTypeDef gpio_init;
+  GPIO_InitTypeDef gpio_init = {0};
   if (hspi->Instance == SPI1) {
     spi1_msp_init();
 

--- a/apps/wheel/src/peripherals.c
+++ b/apps/wheel/src/peripherals.c
@@ -98,7 +98,7 @@ void tim2_init(void) {
     error();
   }
 
-  TIM_IC_InitTypeDef ic_config;
+  TIM_IC_InitTypeDef ic_config = {0};
   ic_config.ICPolarity = TIM_INPUTCHANNELPOLARITY_RISING;
   ic_config.ICSelection = TIM_ICSELECTION_DIRECTTI;
   ic_config.ICPrescaler = TIM_ICPSC_DIV1;
@@ -121,7 +121,7 @@ void dma_init(void) {
 }
 
 void gpio_init(void) {
-  GPIO_InitTypeDef gpio_init;
+  GPIO_InitTypeDef gpio_init = {0};
 
   /* GPIO Ports Clock Enable */
   __HAL_RCC_GPIOF_CLK_ENABLE();
@@ -187,7 +187,7 @@ void HAL_CAN_MspDeInit(CAN_HandleTypeDef* hcan) {
  * @retval None
  */
 void HAL_I2C_MspInit(I2C_HandleTypeDef* hi2c) {
-  GPIO_InitTypeDef gpio_init;
+  GPIO_InitTypeDef gpio_init = {0};
   if (hi2c->Instance == I2C1) {
     __HAL_RCC_GPIOB_CLK_ENABLE();
     /**I2C1 GPIO Configuration
@@ -262,7 +262,7 @@ void HAL_SPI_MspDeInit(SPI_HandleTypeDef* hspi) {
  * @retval None
  */
 void HAL_TIM_Base_MspInit(TIM_HandleTypeDef* htim_base) {
-  GPIO_InitTypeDef gpio_init;
+  GPIO_InitTypeDef gpio_init = {0};
   if (htim_base->Instance == TIM2) {
     /* Peripheral clock enable */
     __HAL_RCC_TIM2_CLK_ENABLE();

--- a/libs/stm32-common/src/clock.c
+++ b/libs/stm32-common/src/clock.c
@@ -2,9 +2,9 @@
 #include "stm32f3xx_hal.h"
 
 void system_clock_init(void) {
-  RCC_OscInitTypeDef rcc_osc_init;
-  RCC_ClkInitTypeDef rcc_clk_init;
-  RCC_PeriphCLKInitTypeDef rcc_periph_clk_init;
+  RCC_OscInitTypeDef rcc_osc_init = {0};
+  RCC_ClkInitTypeDef rcc_clk_init = {0};
+  RCC_PeriphCLKInitTypeDef rcc_periph_clk_init = {0};
 
   /** Initializes the RCC Oscillators according to the specified parameters
    * in the RCC_OscInitTypeDef structure.

--- a/libs/stm32-common/src/common-peripherals.c
+++ b/libs/stm32-common/src/common-peripherals.c
@@ -146,7 +146,7 @@ static void uart1_init(void) {
 }
 
 void can_msp_init(void) {
-  GPIO_InitTypeDef gpio_init;
+  GPIO_InitTypeDef gpio_init = {0};
   /* Peripheral clock enable */
   __HAL_RCC_CAN1_CLK_ENABLE();
 
@@ -184,7 +184,7 @@ void can_msp_deinit(void) {
 }
 
 void spi1_msp_init(void) {
-  GPIO_InitTypeDef gpio_init;
+  GPIO_InitTypeDef gpio_init = {0};
   /* Peripheral clock enable */
   __HAL_RCC_SPI1_CLK_ENABLE();
 
@@ -229,7 +229,7 @@ void spi1_msp_deinit(void) {
 }
 
 void spi2_msp_init(void) {
-  GPIO_InitTypeDef gpio_init;
+  GPIO_InitTypeDef gpio_init = {0};
   /* Peripheral clock enable */
   __HAL_RCC_SPI2_CLK_ENABLE();
 
@@ -274,7 +274,7 @@ void spi2_msp_deinit(void) {
 }
 
 void uart1_msp_init(void) {
-  GPIO_InitTypeDef gpio_init;
+  GPIO_InitTypeDef gpio_init = {0};
   /* Peripheral clock enable */
   __HAL_RCC_USART1_CLK_ENABLE();
 


### PR DESCRIPTION
This change helps prevent potential undefined behavior due to uninitialized variables.
