### PR TITLE
fix(flasher): flush rx buffer after freeze in node detection

### DIFF
--- a/rover_py/flasher/flasher.py
+++ b/rover_py/flasher/flasher.py
@@ -37,6 +37,14 @@ class Flasher:
     def detect_online_nodes(self, restore_comm=True):
         print("Detecting online nodes...")
         self.bus.send(rover.set_action_mode(mode=rover.ActionMode.FREEZE))
+
+        # Let the freeze propagate, then flush the rx buffer. Otherwise report
+        # frames already in flight (e.g. the AD battery monitor's 0x500 cell
+        # voltages) are read below and misidentified as base number responses.
+        time.sleep(self.default_timeout_s)
+        while self.bus.recv(timeout=0) is not None:
+            pass
+
         self.bus.send(rover.give_base_number(response_page=1))
 
         # Check responses


### PR DESCRIPTION
detect_online_nodes() sent FREEZE and give_base_number back-to-back,
then treated any frame with arbitration_id > BASE_NUMBER as a base
number response. Report frames already in flight could slip in before
the freeze took effect -- notably the AD battery monitor's 0x500 cell
voltages, read as node id 0x500 - 0x400 = 256, which is not a valid
City and aborted `fw_update.py list`.

Sleep for the freeze to propagate, then drain the rx buffer before
requesting base numbers, matching the flush idiom already used in
__enter_bootloader and __check_bus_health. Removes the timing race
that made detection depend on the bus already being on-bus.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
